### PR TITLE
Expand documentation content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,57 @@
 # CHANGELOG
+
+## Overview
+This file summarizes notable updates to the repository in reverse
+chronological order.
+
+## Why It Matters
+A clear changelog helps users understand new features, fixes and documentation
+improvements.
+
+## Audience, Scope & Personas
+- Contributors tracking project history
+- Stakeholders reviewing recent changes
+
+## Prerequisites
+- None
+
+## Security, Compliance & Privacy
+Dates and descriptions must not expose sensitive information. Keep entries
+concise.
+
+## Tasks & Step-by-Step Instructions
+1. Add a new heading with the date of your change.
+2. List a short description of the update under that heading.
+
+## Access Control & Permissions (RBAC guidelines)
+Only maintainers update the changelog during the merge process.
+
+## Practical Examples & Templates (✅/❌)
+### 2025-07-30
+✅ Added detailed contribution instructions.
+
+### 2025-01-15
+✅ Initial repository creation.
+
+## Known Issues & Friction Points
+- Keeping entries synchronized with commit history requires diligence.
+
+## Tips & Best Practices
+- Keep descriptions short, ideally one line per change.
+
+## Troubleshooting Guidance
+If a release entry appears missing, check the commit history and confirm whether
+the change was documented elsewhere.
+
+## Dependencies, Risks & Escalation Path
+- Relies on maintainers accurately logging updates.
+- Escalate discrepancies via an issue.
+
+## Success Metrics & Outcomes
+- Clear historical record of repository growth
+
+## Resources & References
+- [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+
+## Last Reviewed / Last Updated
+2025-07-30

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 # CODEOWNERS
+# Specify repository maintainers for automated review assignments
+
+*       @repo-maintainers
+/docs/  @documentation-team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,61 @@
 # CONTRIBUTING
+
+## Overview
+This document explains how to submit issues and pull requests to improve the
+repository.
+
+## Why It Matters
+Clear contribution guidelines help maintain code quality and streamline the
+review process.
+
+## Audience, Scope & Personas
+- External contributors proposing new content
+- Maintainers reviewing and merging changes
+
+## Prerequisites
+- Git and GitHub account
+- Familiarity with the project's README and relevant `AGENTS.md`
+
+## Security, Compliance & Privacy
+Do not include sensitive data in issues or commits. Follow all security and
+privacy guidance defined in the root `AGENTS.md`.
+
+## Tasks & Step-by-Step Instructions
+1. Fork the repository and create a feature branch.
+2. Make your changes while adhering to documentation standards.
+3. Run markdownlint if available and note any issues.
+4. Open a pull request describing your changes and referencing related issues.
+
+## Access Control & Permissions (RBAC guidelines)
+Only maintainers may merge pull requests. Contributors need approval via the
+GitHub review process.
+
+## Practical Examples & Templates (✅/❌)
+✅ Pull request message: "Adds examples to `docs/how-to-navigate.md` and updates
+`LICENSE-CONTENT.md`."
+
+❌ Pull request message: "misc updates" (vague)
+
+## Known Issues & Friction Points
+- Missing or outdated local `AGENTS.md` guidelines can cause confusion.
+
+## Tips & Best Practices
+- Keep pull requests focused on a single goal.
+- Reference related issues in the pull request description.
+
+## Troubleshooting Guidance
+If tests fail or markdownlint cannot run, mention that in the pull request so a
+maintainer can advise next steps.
+
+## Dependencies, Risks & Escalation Path
+- Dependence on GitHub Actions for CI checks
+- Escalate unaddressed reviews via direct mention of maintainers in comments
+
+## Success Metrics & Outcomes
+- Well-documented contributions that merge cleanly
+
+## Resources & References
+- [GitHub Contribution Guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
+
+## Last Reviewed / Last Updated
+2025-07-30

--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,1 +1,54 @@
 # Content License
+
+## Overview
+This repository's written content is provided under the Creative Commons
+Attribution 4.0 International (CC BY 4.0) license.
+
+## Why It Matters
+The license clarifies how others may reuse, modify and distribute the
+documentation.
+
+## Audience, Scope & Personas
+- Anyone interested in reusing or contributing documentation
+
+## Prerequisites
+- Familiarity with basic open-source licensing principles
+
+## Security, Compliance & Privacy
+No personal data is included in the license text. Follow privacy standards when
+submitting content.
+
+## Tasks & Step-by-Step Instructions
+1. Include attribution to the original author when reusing content.
+2. Indicate if you made any modifications.
+
+## Access Control & Permissions (RBAC guidelines)
+The license permits commercial and non-commercial use provided attribution is
+given.
+
+## Practical Examples & Templates (✅/❌)
+✅ "Content adapted from the Techno-Functional Portfolio under CC BY 4.0."
+
+❌ "Content copied with no attribution."
+
+## Known Issues & Friction Points
+- Some contributors may be unfamiliar with Creative Commons requirements.
+
+## Tips & Best Practices
+- Provide a link to this file whenever you reuse material externally.
+
+## Troubleshooting Guidance
+For questions on acceptable use, consult the repository maintainers.
+
+## Dependencies, Risks & Escalation Path
+- Proper attribution is required to comply with the license.
+- Escalate disputes or violations through repository issues.
+
+## Success Metrics & Outcomes
+- Clear reuse rights promote collaboration.
+
+## Resources & References
+- [Creative Commons CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+## Last Reviewed / Last Updated
+2025-07-30

--- a/LICENSE-MIT.md
+++ b/LICENSE-MIT.md
@@ -1,1 +1,74 @@
 # MIT License
+
+## Overview
+This project uses the MIT License, a permissive open-source license that allows
+reuse with minimal restrictions.
+
+## Why It Matters
+The license encourages wide adoption of the code while protecting contributors
+from liability.
+
+## Audience, Scope & Personas
+- Developers and organizations reusing the source code
+
+## Prerequisites
+- None
+
+## Security, Compliance & Privacy
+The license does not grant rights to use trademarks or contributor names. No
+personal data is collected.
+
+## Tasks & Step-by-Step Instructions
+1. Include the following license text with any redistributed copies of the
+   software.
+
+```
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Access Control & Permissions (RBAC guidelines)
+The MIT License grants broad permissions as long as the license text is
+included with distributions.
+
+## Practical Examples & Templates (✅/❌)
+✅ Use portions of the code in another project while including this license.
+
+❌ Redistribute code without including the license text.
+
+## Known Issues & Friction Points
+- Misplacing or omitting the license text can create legal ambiguity.
+
+## Tips & Best Practices
+- Keep this file intact whenever you fork or reuse the repository.
+
+## Troubleshooting Guidance
+If you are unsure about permitted uses, consult legal counsel or open an issue
+for clarification.
+
+## Dependencies, Risks & Escalation Path
+- Ensure derivative works respect the original license terms.
+
+## Success Metrics & Outcomes
+- Code reuse without licensing disputes
+
+## Resources & References
+- [Open Source Initiative MIT](https://opensource.org/licenses/MIT)
+
+## Last Reviewed / Last Updated
+2025-07-30

--- a/docs/glossary-of-terms.md
+++ b/docs/glossary-of-terms.md
@@ -1,8 +1,70 @@
 # Glossary of Terms
 
+## Overview
+This file defines common vocabulary used across the portfolio to ensure
+consistent understanding between contributors.
+
+## Why It Matters
+Clear terminology reduces miscommunication and accelerates onboarding for
+new team members.
+
+## Audience, Scope & Personas
+- Contributors new to the repository
+- Cross‑functional stakeholders collaborating on projects
+
+## Prerequisites
+- Basic familiarity with software development and content management
+  concepts
+
+## Security, Compliance & Privacy
+This glossary contains no sensitive data. It references security-related terms
+to promote awareness of best practices.
+
+## Tasks & Step-by-Step Instructions
+1. Locate the term you are unsure about.
+2. Review its definition and linked resources.
+3. If a key term is missing, open an issue to request an update.
+
+## Access Control & Permissions (RBAC guidelines)
+The glossary is read-only for most contributors. Only maintainers can approve
+new entries.
+
+## Practical Examples & Templates (✅/❌)
 | Term | Definition |
 |------|------------|
 | CI/CD | Continuous Integration and Continuous Deployment |
 | ContentOps | Processes that govern content creation and delivery |
 | RBAC | Role-Based Access Control |
----
+| DevOps | Collaboration between development and operations to automate delivery |
+| PR | Pull Request |
+
+✅ Correct usage: "Update the CI/CD pipeline."
+
+❌ Incorrect usage: "Update the CICD pipeline" (missing slash)
+
+## Known Issues & Friction Points
+Some abbreviations have multiple interpretations across industries. Confirm the
+definition aligns with this repository before using a term in documentation.
+
+## Tips & Best Practices
+- Keep definitions short and action oriented.
+- Provide links to external references when useful.
+
+## Troubleshooting Guidance
+If a term seems unclear or has multiple meanings, raise a question in the issue
+tracker to clarify it before proceeding.
+
+## Dependencies, Risks & Escalation Path
+- No direct dependencies.
+- Escalate unresolved terminology questions to the repository maintainers.
+
+## Success Metrics & Outcomes
+- Shared vocabulary across documentation and projects
+
+## Resources & References
+- [Wikipedia](https://en.wikipedia.org/wiki/Glossary)
+- [DevOps Glossary](https://www.atlassian.com/devops/devops-tools/devops-glossary)
+
+## Last Reviewed / Last Updated
+2025-07-30
+

--- a/docs/how-to-navigate.md
+++ b/docs/how-to-navigate.md
@@ -1,6 +1,65 @@
 # How to Navigate
 
-1. Review the top-level `README.md` for an overview of directories.
-2. Each folder contains a `README.md` describing its focus.
-3. Consult `AGENTS.md` files for writing and security standards.
----
+## Overview
+This guide explains how to locate key information and contribute efficiently
+within this repository.
+
+## Why It Matters
+Following a consistent navigation approach helps all contributors find the right
+resources quickly and reduces ramp-up time.
+
+## Audience, Scope & Personas
+- New contributors
+- Experienced maintainers who need a refresher
+
+## Prerequisites
+- Familiarity with Git and GitHub basics
+
+## Security, Compliance & Privacy
+Always review directory-specific `AGENTS.md` files for security and compliance
+guidelines before committing changes.
+
+## Tasks & Step-by-Step Instructions
+1. Start at the top-level `README.md` for a high-level overview of the
+   repository structure.
+2. Navigate into each folder and read the local `README.md` to understand its
+   purpose.
+3. Consult the appropriate `AGENTS.md` for required writing standards and
+   security considerations.
+4. Use the `docs/` directory for additional references like the glossary and
+   workflow explanations.
+
+## Access Control & Permissions (RBAC guidelines)
+Most documentation is publicly readable. Merge permissions are limited to the
+maintainers specified in `CODEOWNERS`.
+
+## Practical Examples & Templates (✅/❌)
+✅ "Refer to `/05-automation-ci-cd/README.md` for CI/CD guidelines."
+
+❌ "Just guess which folder holds the automation docs."
+
+## Known Issues & Friction Points
+- Large directory trees can feel overwhelming at first glance.
+- Some files may have overlapping information.
+
+## Tips & Best Practices
+- Use GitHub's search to locate files quickly.
+- Bookmark the `docs/` directory for reference material.
+
+## Troubleshooting Guidance
+If a link in any README or documentation appears broken, open an issue so it can
+be corrected promptly.
+
+## Dependencies, Risks & Escalation Path
+- Navigation relies on accurate README and `AGENTS.md` content.
+- Escalate persistent confusion to repository maintainers.
+
+## Success Metrics & Outcomes
+- Contributors can locate information without assistance.
+
+## Resources & References
+- [GitHub Documentation](https://docs.github.com/en)
+
+## Last Reviewed / Last Updated
+2025-07-30
+

--- a/docs/overview-of-repo.md
+++ b/docs/overview-of-repo.md
@@ -1,13 +1,59 @@
 # Overview of Repo
 
-This repository organizes content and automation guidelines for Shailesh's portfolio.
+## Overview
+This repository houses documentation, automation logic and workflow templates
+that demonstrate best practices across business analysis, communications and
+technical enablement.
 
-## Contents
-- Business analysis methods and templates
-- Change communication strategies
-- Technical documentation standards
-- AI-driven content workflows
-- CI/CD automation scripts
+## Why It Matters
+A consistent structure makes it easier for contributors to locate examples and
+extend the portfolio for their own needs.
 
-Refer to each directory's `README.md` for detailed instructions.
----
+## Audience, Scope & Personas
+- Content strategists looking for repeatable patterns
+- Developers and automation engineers
+- Stakeholders reviewing technical change initiatives
+
+## Prerequisites
+- Familiarity with GitHub basics and markdown editing
+
+## Security, Compliance & Privacy
+Ensure all contributions follow the security guidelines outlined in the root
+`AGENTS.md`. Do not include sensitive information in any commit.
+
+## Tasks & Step-by-Step Instructions
+1. Review the folder names for a thematic breakdown of assets.
+2. Open the relevant `README.md` to learn about the purpose of each folder.
+3. Follow `AGENTS.md` instructions before modifying or adding content.
+
+## Access Control & Permissions (RBAC guidelines)
+Write access is limited to maintainers listed in `CODEOWNERS`. External
+contributions require pull requests for review.
+
+## Practical Examples & Templates (✅/❌)
+- ✅ Store automation scripts under `05-automation-ci-cd/`.
+- ❌ Mix unrelated personal files into project folders.
+
+## Known Issues & Friction Points
+- Some areas still contain placeholder content awaiting expansion.
+
+## Tips & Best Practices
+- Keep directory names short and descriptive.
+- Cross‑reference related documents to avoid duplication.
+
+## Troubleshooting Guidance
+If you cannot find a file, use the repository search or consult the glossary.
+
+## Dependencies, Risks & Escalation Path
+- None for general navigation
+- Escalate repository access issues to maintainers
+
+## Success Metrics & Outcomes
+- Faster onboarding for new contributors
+
+## Resources & References
+- Internal documentation style guides
+
+## Last Reviewed / Last Updated
+2025-07-30
+


### PR DESCRIPTION
## Summary
- expand glossary of terms
- elaborate navigation instructions
- provide fuller repo overview
- flesh out contributing guide and changelog
- document content and MIT licenses
- add CODEOWNERS entries

## Testing
- `markdownlint docs/glossary-of-terms.md docs/how-to-navigate.md docs/overview-of-repo.md CONTRIBUTING.md CHANGELOG.md LICENSE-CONTENT.md LICENSE-MIT.md CODEOWNERS` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c7b0d0448322918eedac917c7649