### PR TITLE
Add assets folder with documentation

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,49 @@
+# Assets
+
+## Overview
+This directory stores project visuals, diagrams, and screenshots referenced throughout the documentation.
+
+## Why It Matters
+Centralizing graphics ensures you can easily maintain and reference visual assets across documents.
+
+## Audience, Scope & Personas
+All contributors using or adding images, diagrams, or screenshots to support documentation.
+
+## Prerequisites
+- Ensure images contain no sensitive information.
+
+## Security, Compliance & Privacy
+Follow global repository guidelines; avoid embedding confidential data in graphics.
+
+## Tasks & Step-by-Step Instructions
+1. Add new graphics in the appropriate subfolder: `diagrams`, `visuals`, or `screenshots`.
+2. Commit the assets with meaningful file names.
+
+## Access Control & Permissions (RBAC guidelines)
+Only maintainers with write access may commit new images.
+
+## Practical Examples & Templates (✅/❌)
+- ✅ `diagram-system-architecture.png`
+- ❌ `image1.png`
+
+## Known Issues & Friction Points
+Large image files may increase repository size.
+
+## Tips & Best Practices
+- Use descriptive file names in kebab-case.
+- Optimize images for size and clarity.
+
+## Troubleshooting Guidance
+If assets do not render correctly, verify the file path in your markdown.
+
+## Dependencies, Risks & Escalation Path
+Large assets might exceed repository limits; raise concerns to maintainers.
+
+## Success Metrics & Outcomes
+Consistent, easily maintainable visuals across documentation.
+
+## Resources & References
+Refer to `AGENTS.md` for content governance guidelines.
+
+## Last Reviewed / Last Updated
+30 July 2025

--- a/assets/diagrams/README.md
+++ b/assets/diagrams/README.md
@@ -1,0 +1,7 @@
+# Diagrams
+
+## Overview
+Store system and process diagrams here.
+
+## Last Reviewed / Last Updated
+30 July 2025

--- a/assets/screenshots/README.md
+++ b/assets/screenshots/README.md
@@ -1,0 +1,7 @@
+# Screenshots
+
+## Overview
+Store workflow screenshots here for reference in documentation.
+
+## Last Reviewed / Last Updated
+30 July 2025

--- a/assets/visuals/README.md
+++ b/assets/visuals/README.md
@@ -1,0 +1,7 @@
+# Visuals
+
+## Overview
+Store UI mockups or design assets here.
+
+## Last Reviewed / Last Updated
+30 July 2025


### PR DESCRIPTION
## Summary
- add an `assets` directory with `diagrams`, `visuals`, and `screenshots` subfolders
- document usage of each folder in dedicated READMEs

## Testing
- `markdownlint '**/*.md'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d00ab56c83229d08ba88ccb1b014