### PR TITLE
Add standard ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,50 @@
 # Gitignore
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Python caches and compiled files
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Python virtual environments
+.env/
+.venv/
+venv/
+env/
+
+# Build artifacts
+build/
+dist/
+.eggs/
+*.egg-info/
+*.egg
+pip-wheel-metadata/
+
+# Test and coverage outputs
+htmlcov/
+.coverage
+.cache/
+.pytest_cache/
+coverage.xml
+
+# Logs and temporary files
+*.log
+*.tmp
+*.swp
+*~
+
+# Editor directories
+.vscode/
+.idea/
+
+# Node artifacts (if any)
+node_modules/
+
+# Documentation build output
+site/
+public/
+


### PR DESCRIPTION
## Summary
- add common patterns for OS-specific files, Python caches, build artifacts, and more

## Testing
- `bash scripts/validate-docs.sh`
- `markdownlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d0714c788322aaaa35279343efd1