### PR TITLE
Add markdownlint setup script

### DIFF
--- a/.github/workflows/markdown-validation.yml
+++ b/.github/workflows/markdown-validation.yml
@@ -25,10 +25,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🛠️ Set script permissions
-        run: chmod +x ./scripts/validate-docs.sh
+        run: |
+          chmod +x ./scripts/setup-environment.sh
+          chmod +x ./scripts/validate-docs.sh
 
-      - name: 📦 Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+      - name: 📦 Setup environment
+        run: ./scripts/setup-environment.sh
 
       - name: 🧪 Run validation script
         run: ./scripts/validate-docs.sh

--- a/05-automation-ci-cd/README.md
+++ b/05-automation-ci-cd/README.md
@@ -16,7 +16,7 @@
 - Store secrets in encrypted variables and audit access.
 
 ## Step-by-Step Automation Tasks
-1. Run `scripts/setup-env.sh` to install tools.
+1. Run `scripts/setup-environment.sh` to install tools.
 2. Commit changes and push to trigger CI.
 3. Review build results in GitHub Actions.
 
@@ -24,7 +24,7 @@
 - See `.github/workflows/ci-build.yml` for a minimal build job.
 
 ## Known Automation Issues & Mitigation
-- Missing dependencies cause build failures; run `setup-env.sh` first.
+- Missing dependencies cause build failures; run `setup-environment.sh` first.
 
 ## Automation Best Practices
 - Keep workflows simple and version-controlled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,10 @@ privacy guidance defined in the root `AGENTS.md`.
 
 ## Tasks & Step-by-Step Instructions
 1. Fork the repository and create a feature branch.
-2. Make your changes while adhering to documentation standards.
-3. Run markdownlint if available and note any issues.
-4. Open a pull request describing your changes and referencing related issues.
+2. Run `scripts/setup-environment.sh` to install markdownlint-cli2 and other tools.
+3. Make your changes while adhering to documentation standards.
+4. Run markdownlint if available and note any issues.
+5. Open a pull request describing your changes and referencing related issues.
 
 ## Access Control & Permissions (RBAC guidelines)
 Only maintainers may merge pull requests. Contributors need approval via the

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,1 +1,9 @@
 #!/bin/bash
+set -euo pipefail
+
+# scripts/setup-env.sh
+# Deprecated helper that forwards to setup-environment.sh for
+# compatibility with older documentation references.
+
+DIR="$(dirname "$0")"
+"${DIR}/setup-environment.sh"

--- a/scripts/setup-environment.sh
+++ b/scripts/setup-environment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# scripts/setup-environment.sh
+# Install required tooling for documentation validation.
+
+echo "📦 Installing markdownlint-cli2..."
+npm install -g markdownlint-cli2
+
+echo "✅ Environment setup complete."


### PR DESCRIPTION
## Summary
- create `scripts/setup-environment.sh` to install `markdownlint-cli2`
- update `scripts/setup-env.sh` to call the new script
- reference the setup script in CONTRIBUTING and automation docs
- run setup script in CI before markdown validation

## Testing
- `./scripts/setup-environment.sh` *(fails: 403 Forbidden)*
- `./scripts/validate-docs.sh` *(fails: markdownlint-cli2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889eae751388322b13ed5c27b1c0f01