### PR TITLE
chore: add markdownlint ignore file

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,13 @@
+# Ignore dependency directories
+node_modules/
+.env/
+.venv/
+venv/
+env/
+
+# Ignore build and output directories
+build/
+dist/
+coverage/
+site/
+public/

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -15,7 +15,7 @@ if ! [ -f "node_modules/.bin/markdownlint-cli2" ]; then
   exit 1
 fi
 
-# Step 2: Run markdownlint using npx
+# Step 2: Run markdownlint using npx (respects patterns in .markdownlintignore)
 echo "✅ Running markdownlint-cli2 (local)..."
 npx markdownlint-cli2 "**/*.md" --config "$CONFIG_FILE"
 


### PR DESCRIPTION
## Summary
- add `.markdownlintignore` to keep dependencies and build output out of lint checks
- document ignore support in `scripts/validate-docs.sh`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `./scripts/validate-docs.sh` *(fails: MD022 and MD032 in style-guide/visual-style.md)*

------
https://chatgpt.com/codex/tasks/task_e_688df35846d083228017c6a6112171a0