### PR TITLE
chore: add lint and test scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+title: "CONTRIBUTING"
+archetype: "contributor-guide"
+status: "stable"
+owner: "Shailesh Rawat"
+maintainer: "Shailesh Rawat"
+version: "1.0"
+tags: ["contributing", "guidelines"]
+last_reviewed: "2025-08-02"
+---
 # CONTRIBUTING
 
 ## Overview
@@ -16,6 +26,8 @@ review process.
 - Git and GitHub account
 - Familiarity with the project's README and relevant `AGENTS.md`
 
+> ℹ️ **Note:** This guide assumes you have Node.js and npm installed.
+
 ## Security, Compliance & Privacy
 Do not include sensitive data in issues or commits. Follow all security and
 privacy guidance defined in the root `AGENTS.md`.
@@ -24,8 +36,9 @@ privacy guidance defined in the root `AGENTS.md`.
 1. Fork the repository and create a feature branch.
 2. Run `scripts/setup-environment.sh` to install markdownlint-cli2 and other tools.
 3. Make your changes while adhering to documentation standards.
-4. Run markdownlint if available and note any issues.
-5. Open a pull request describing your changes and referencing related issues.
+4. Run `npm run lint` to validate Markdown formatting.
+5. Run `npm test`; the current suite prints "No tests".
+6. Open a pull request describing your changes and referencing related issues.
 
 ## Access Control & Permissions (RBAC guidelines)
 Only maintainers may merge pull requests. Contributors need approval via the
@@ -59,4 +72,6 @@ maintainer can advise next steps.
 - [GitHub Contribution Guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
 
 ## Last Reviewed / Last Updated
-2025-07-30
+Date: 2025-08-02  
+Maintainer: Shailesh Rawat (PoeticMayhem)  
+Status: Stable – Version 1.0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "markdownlint-cli2 '**/*.md' '!node_modules'",
+    "test": "echo \"No tests\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add markdown lint and placeholder test scripts
- document how to run lint and tests in contributing guide

## Testing
- `npm run lint` (fails: 1815 errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df3716b508322bba6b3d27fbad1e1