### PR TITLE
chore: standardize markdown formatting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,13 +1,8 @@
 {
-  "default": true,
-  "MD001": { "level": 2 },
-  "MD003": { "style": "atx" },
+  "default": false,
   "MD004": { "style": "dash" },
-  "MD007": { "indent": 2 },
-  "MD013": { "line_length": 120, "tables": false },
-  "MD025": { "front_matter_title": "title" },
-  "MD038": true,
-  "MD041": true,
-  "MD042": true,
-  "MD045": { "image_alt_text": true }
+  "MD022": true,
+  "MD032": true,
+  "MD035": { "style": "---" },
+  "MD040": true
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,13 @@
+# Ignore dependency directories
+node_modules/
+.env/
+.venv/
+venv/
+env/
+
+# Ignore build and output directories
+build/
+dist/
+coverage/
+site/
+public/

--- a/01-business-analysis/AGENTS.md
+++ b/01-business-analysis/AGENTS.md
@@ -1,11 +1,13 @@
 # AGENTS.md – Technical Business Analysis Standards
 
 ## 📌 General Guidance
+
 - Always use clear, structured, business-centric language.
 - Maintain second-person ("you") voice for clarity.
 - Document assumptions explicitly and clearly state business rationale.
 
 ## 🗂️ Required Structure
+
 1. Overview (Brief, clear business context)
 2. Business Value & Importance
 3. Target Audience & Key Stakeholders
@@ -21,22 +23,26 @@
 13. Last Reviewed / Updated
 
 ## 💡 Formatting Rules
+
 - Clear markdown hierarchy (`##`, `###`)
 - Bullet-points and tables preferred over lengthy paragraphs
 - Explicit User Stories (As a <Role>, I want <Goal>, so that <Benefit>)
 
 ## 🚩 Commit & PR Guidelines
+
 - Clear, business-centric commit messages.
 - Pull requests must explicitly state business impact and reviewed security considerations.
 
 ## 🔐 Security & Compliance
+
 - Explicitly define risks, data security guidelines, and compliance requirements (GDPR, ISO, etc.)
 - Document recommended data-handling processes clearly.
 
 ## 📊 Checks & Validations
+
 - Validate clearly against markdownlint before commits.
 - Run explicit requirement coverage checklists if provided.
 
 ## 🔄 Review Schedule
-- Quarterly review or immediately after business/process changes.
 
+- Quarterly review or immediately after business/process changes.

--- a/01-business-analysis/README.md
+++ b/01-business-analysis/README.md
@@ -133,7 +133,7 @@ Before initiating business analysis tasks:
 As a hiring manager,  
 I want to receive alerts when candidate documents are incomplete,  
 So that I can take immediate action and reduce onboarding delays.
-````
+```
 
 ### ❌ Bad Example: Vague Requirement
 
@@ -157,17 +157,17 @@ So that I can take immediate action and reduce onboarding delays.
 
 ### ✅ Do
 
-* Visualize workflows wherever possible
-* Use structured frameworks (e.g., SIPOC, SWOT, 5 Whys)
-* Validate findings iteratively with stakeholders
-* Maintain a glossary of recurring terms
+- Visualize workflows wherever possible
+- Use structured frameworks (e.g., SIPOC, SWOT, 5 Whys)
+- Validate findings iteratively with stakeholders
+- Maintain a glossary of recurring terms
 
 ### ❌ Don’t
 
-* Assume stakeholder clarity on business goals
-* Use technical language in business-facing docs
-* Delay signoffs indefinitely—set validation timelines
-* Skip user-facing validation before documentation handoff
+- Assume stakeholder clarity on business goals
+- Use technical language in business-facing docs
+- Delay signoffs indefinitely—set validation timelines
+- Skip user-facing validation before documentation handoff
 
 ---
 
@@ -218,11 +218,11 @@ So that I can take immediate action and reduce onboarding delays.
 
 ## Resources & References
 
-* [Gap Analysis Framework](./gap-analysis-framework.md)
-* [User Story Writing Guide](./user-stories-guide.md)
-* [Business Requirements Template](./templates/brd-template.md)
-* [Stakeholder Interview Template](./templates/stakeholder-interview.md)
-* [Process Mapping Reference (BPMN)](./visual-tools/bpmn-basics.md)
+- [Gap Analysis Framework](./gap-analysis-framework.md)
+- [User Story Writing Guide](./user-stories-guide.md)
+- [Business Requirements Template](./templates/brd-template.md)
+- [Stakeholder Interview Template](./templates/stakeholder-interview.md)
+- [Process Mapping Reference (BPMN)](./visual-tools/bpmn-basics.md)
 
 ---
 
@@ -232,4 +232,3 @@ So that I can take immediate action and reduce onboarding delays.
 **Maintainer:** Shailesh Rawat (PoeticMayhem)
 **Version:** v1.0
 **Status:** ✅ Stable
-

--- a/01-business-analysis/acceptance-criteria-guide.md
+++ b/01-business-analysis/acceptance-criteria-guide.md
@@ -87,7 +87,7 @@ This guide applies to writing and reviewing acceptance criteria for:
 Given [initial context],
 When [action taken],
 Then [expected outcome]
-````
+```
 
 Example:
 
@@ -99,25 +99,25 @@ Then I should see the 'Add User' button.
 
 ### 2. Write Plain Language Criteria
 
-* Focus on observable outcomes
-* Avoid implementation details or internal logic
-* Use bullets or numbered lists when Gherkin is not used
+- Focus on observable outcomes
+- Avoid implementation details or internal logic
+- Use bullets or numbered lists when Gherkin is not used
 
 Example:
 
-* The password reset email is sent within 2 minutes
-* Error message appears if username is missing
-* User is redirected to dashboard after login
+- The password reset email is sent within 2 minutes
+- Error message appears if username is missing
+- User is redirected to dashboard after login
 
 ### 3. Define Success Boundaries
 
-* Specify “done” vs. “incomplete” behaviors
-* Include edge cases and negative validations (e.g., failed login, API timeout)
+- Specify “done” vs. “incomplete” behaviors
+- Include edge cases and negative validations (e.g., failed login, API timeout)
 
 ### 4. Review with QA and Product Teams
 
-* Ensure all test scenarios are covered
-* Validate that each criterion is **testable, observable, and unambiguous**
+- Ensure all test scenarios are covered
+- Validate that each criterion is **testable, observable, and unambiguous**
 
 ---
 
@@ -168,17 +168,17 @@ Example:
 
 ### ✅ Do
 
-* Start criteria before development begins
-* Align with Definition of Done per team or sprint
-* Add accessibility and mobile behavior if relevant
-* Review and update criteria after stakeholder feedback
+- Start criteria before development begins
+- Align with Definition of Done per team or sprint
+- Add accessibility and mobile behavior if relevant
+- Review and update criteria after stakeholder feedback
 
 ### ❌ Don’t
 
-* Assume dev or QA will “figure it out”
-* Reuse generic acceptance criteria for every story
-* Use vague words like “intuitive” or “efficient”
-* Leave out error handling and edge behavior
+- Assume dev or QA will “figure it out”
+- Reuse generic acceptance criteria for every story
+- Use vague words like “intuitive” or “efficient”
+- Leave out error handling and edge behavior
 
 ---
 
@@ -226,10 +226,10 @@ Example:
 
 ## Resources & References
 
-* [Gherkin Syntax – cucumber.io](https://cucumber.io/docs/gherkin/)
-* [Agile Alliance – Definition of Done](https://www.agilealliance.org/glossary/definition-of-done/)
-* [Internal QA Mapping Template](./qa-criteria-mapping.md)
-* [Accessibility Acceptance Guide](./ux-accessibility-criteria.md)
+- [Gherkin Syntax – cucumber.io](https://cucumber.io/docs/gherkin/)
+- [Agile Alliance – Definition of Done](https://www.agilealliance.org/glossary/definition-of-done/)
+- [Internal QA Mapping Template](./qa-criteria-mapping.md)
+- [Accessibility Acceptance Guide](./ux-accessibility-criteria.md)
 
 ---
 

--- a/01-business-analysis/business-process-mapping.md
+++ b/01-business-analysis/business-process-mapping.md
@@ -24,11 +24,11 @@ Gap analysis is a structured method to compare your organization's current capab
 
 Gap analysis helps organizations:
 
-* Maximize focus on initiatives with measurable business value
-* Avoid wasted resources on low-impact activities
-* Align cross-functional teams on goals and expectations
-* Present issues as quantifiable gaps, fostering shared understanding
-* Improve budgeting, risk mitigation, and compliance tracking
+- Maximize focus on initiatives with measurable business value
+- Avoid wasted resources on low-impact activities
+- Align cross-functional teams on goals and expectations
+- Present issues as quantifiable gaps, fostering shared understanding
+- Improve budgeting, risk mitigation, and compliance tracking
 
 It moves teams from vague frustration to documented, data-backed clarity.
 
@@ -38,44 +38,44 @@ It moves teams from vague frustration to documented, data-backed clarity.
 
 ### Audience
 
-* Business Analysts, Transformation Consultants
-* Product Managers, Ops Leads
-* Executive Sponsors, Department Heads
+- Business Analysts, Transformation Consultants
+- Product Managers, Ops Leads
+- Executive Sponsors, Department Heads
 
 ### Personas
 
-* **Project Sponsor**: Approves and funds change initiatives
-* **Analyst/Consultant**: Coordinates discovery and analysis
-* **Functional Heads**: Provide insights into current workflows
-* **Compliance Officers**: Safeguard data integrity and legal boundaries
+- **Project Sponsor**: Approves and funds change initiatives
+- **Analyst/Consultant**: Coordinates discovery and analysis
+- **Functional Heads**: Provide insights into current workflows
+- **Compliance Officers**: Safeguard data integrity and legal boundaries
 
 ### Scope
 
 Applies to:
 
-* Internal process improvement
-* Strategic planning
-* Digital transformation assessments
+- Internal process improvement
+- Strategic planning
+- Digital transformation assessments
 
 ---
 
 ## Prerequisites
 
-* ✅ Baseline metrics (cycle time, error rate, etc.)
-* ✅ Documented business objectives
-* ✅ Stakeholder commitment and availability
-* ✅ Data access approvals (security, system owners)
-* ✅ Secure storage and retention plan
+- ✅ Baseline metrics (cycle time, error rate, etc.)
+- ✅ Documented business objectives
+- ✅ Stakeholder commitment and availability
+- ✅ Data access approvals (security, system owners)
+- ✅ Secure storage and retention plan
 
 ---
 
 ## Security, Compliance & Privacy
 
-* Follow **data minimization**: collect only what is required
-* Store data securely with access controls and encryption
-* Ensure all stakeholder data is anonymized if shared externally
-* Align with **GDPR**, **SOC2**, or **ISO 27001** if applicable
-* Clearly mark sensitive outputs and maintain audit trails
+- Follow **data minimization**: collect only what is required
+- Store data securely with access controls and encryption
+- Ensure all stakeholder data is anonymized if shared externally
+- Align with **GDPR**, **SOC2**, or **ISO 27001** if applicable
+- Clearly mark sensitive outputs and maintain audit trails
 
 ---
 
@@ -83,43 +83,43 @@ Applies to:
 
 ### 1. Define the Scope
 
-* Identify systems, processes, or teams in focus
-* Document boundaries, assumptions, and constraints
+- Identify systems, processes, or teams in focus
+- Document boundaries, assumptions, and constraints
 
 ### 2. Collect Current State Data
 
-* Use interviews, surveys, dashboards, and audits
-* Include qualitative (employee friction) and quantitative metrics
+- Use interviews, surveys, dashboards, and audits
+- Include qualitative (employee friction) and quantitative metrics
 
 ### 3. Describe Desired Future State
 
-* Map business goals to measurable outcomes
-* Translate abstract aims into KPIs or SLAs
+- Map business goals to measurable outcomes
+- Translate abstract aims into KPIs or SLAs
 
 ### 4. Identify and Categorize Gaps
 
-* Compare current vs. desired metrics
-* Categorize gaps: skill, tech, process, structural
+- Compare current vs. desired metrics
+- Categorize gaps: skill, tech, process, structural
 
 ### 5. Assess Root Causes
 
-* Use 5 Whys, Fishbone diagrams, or stakeholder workshops
+- Use 5 Whys, Fishbone diagrams, or stakeholder workshops
 
 ### 6. Prioritize
 
-* Score each gap: \[Impact × Effort × Risk Reduction]
+- Score each gap: \[Impact × Effort × Risk Reduction]
 
 ### 7. Develop Action Plans
 
-* Assign owners, define timelines, link to OKRs
+- Assign owners, define timelines, link to OKRs
 
 ### 8. Review & Validate
 
-* Schedule feedback sessions to align on root causes and fixes
+- Schedule feedback sessions to align on root causes and fixes
 
 ### 9. Finalize & Communicate
 
-* Create executive summaries, dashboards, and slides for stakeholders
+- Create executive summaries, dashboards, and slides for stakeholders
 
 ---
 
@@ -167,17 +167,17 @@ so that customers receive quicker resolutions.
 
 ### ✅ Do
 
-* Use visuals like heat maps to display gap clusters
-* Validate early with partial reviews
-* Categorize gaps and use scoring to prioritize
-* Include assumptions explicitly in a shared doc
+- Use visuals like heat maps to display gap clusters
+- Validate early with partial reviews
+- Categorize gaps and use scoring to prioritize
+- Include assumptions explicitly in a shared doc
 
 ### ❌ Don’t
 
-* Skip stakeholder interviews
-* Let ambiguity persist in KPI definitions
-* Assume legacy reports reflect real current state
-* Present final output without review loop
+- Skip stakeholder interviews
+- Let ambiguity persist in KPI definitions
+- Assume legacy reports reflect real current state
+- Present final output without review loop
 
 ---
 
@@ -226,11 +226,11 @@ so that customers receive quicker resolutions.
 
 ## Resources & References
 
-* [Gap Analysis Template – Spreadsheet](./gap-analysis-template.xlsx)
-* [Stakeholder Interview Guide](./stakeholder-interview-guide.md)
-* [KPI Mapping Table](./kpi-mapping-table.md)
-* [Scoring Model Reference](./impact-effort-risk-scorer.md)
-* [Visualization Tools – Guide](./gap-analysis-visual-aids.md)
+- [Gap Analysis Template – Spreadsheet](./gap-analysis-template.xlsx)
+- [Stakeholder Interview Guide](./stakeholder-interview-guide.md)
+- [KPI Mapping Table](./kpi-mapping-table.md)
+- [Scoring Model Reference](./impact-effort-risk-scorer.md)
+- [Visualization Tools – Guide](./gap-analysis-visual-aids.md)
 
 ---
 

--- a/01-business-analysis/gap-analysis-framework.md
+++ b/01-business-analysis/gap-analysis-framework.md
@@ -24,11 +24,11 @@ Gap analysis is a structured method to compare your organization's current capab
 
 Gap analysis helps organizations:
 
-* Maximize focus on initiatives with measurable business value
-* Avoid wasted resources on low-impact activities
-* Align cross-functional teams on goals and expectations
-* Present issues as quantifiable gaps, fostering shared understanding
-* Improve budgeting, risk mitigation, and compliance tracking
+- Maximize focus on initiatives with measurable business value
+- Avoid wasted resources on low-impact activities
+- Align cross-functional teams on goals and expectations
+- Present issues as quantifiable gaps, fostering shared understanding
+- Improve budgeting, risk mitigation, and compliance tracking
 
 It moves teams from vague frustration to documented, data-backed clarity.
 
@@ -38,44 +38,44 @@ It moves teams from vague frustration to documented, data-backed clarity.
 
 ### Audience
 
-* Business Analysts, Transformation Consultants
-* Product Managers, Ops Leads
-* Executive Sponsors, Department Heads
+- Business Analysts, Transformation Consultants
+- Product Managers, Ops Leads
+- Executive Sponsors, Department Heads
 
 ### Personas
 
-* **Project Sponsor**: Approves and funds change initiatives
-* **Analyst/Consultant**: Coordinates discovery and analysis
-* **Functional Heads**: Provide insights into current workflows
-* **Compliance Officers**: Safeguard data integrity and legal boundaries
+- **Project Sponsor**: Approves and funds change initiatives
+- **Analyst/Consultant**: Coordinates discovery and analysis
+- **Functional Heads**: Provide insights into current workflows
+- **Compliance Officers**: Safeguard data integrity and legal boundaries
 
 ### Scope
 
 Applies to:
 
-* Internal process improvement
-* Strategic planning
-* Digital transformation assessments
+- Internal process improvement
+- Strategic planning
+- Digital transformation assessments
 
 ---
 
 ## Prerequisites
 
-* ✅ Baseline metrics (cycle time, error rate, etc.)
-* ✅ Documented business objectives
-* ✅ Stakeholder commitment and availability
-* ✅ Data access approvals (security, system owners)
-* ✅ Secure storage and retention plan
+- ✅ Baseline metrics (cycle time, error rate, etc.)
+- ✅ Documented business objectives
+- ✅ Stakeholder commitment and availability
+- ✅ Data access approvals (security, system owners)
+- ✅ Secure storage and retention plan
 
 ---
 
 ## Security, Compliance & Privacy
 
-* Follow **data minimization**: collect only what is required
-* Store data securely with access controls and encryption
-* Ensure all stakeholder data is anonymized if shared externally
-* Align with **GDPR**, **SOC2**, or **ISO 27001** if applicable
-* Clearly mark sensitive outputs and maintain audit trails
+- Follow **data minimization**: collect only what is required
+- Store data securely with access controls and encryption
+- Ensure all stakeholder data is anonymized if shared externally
+- Align with **GDPR**, **SOC2**, or **ISO 27001** if applicable
+- Clearly mark sensitive outputs and maintain audit trails
 
 ---
 
@@ -83,43 +83,43 @@ Applies to:
 
 ### 1. Define the Scope
 
-* Identify systems, processes, or teams in focus
-* Document boundaries, assumptions, and constraints
+- Identify systems, processes, or teams in focus
+- Document boundaries, assumptions, and constraints
 
 ### 2. Collect Current State Data
 
-* Use interviews, surveys, dashboards, and audits
-* Include qualitative (employee friction) and quantitative metrics
+- Use interviews, surveys, dashboards, and audits
+- Include qualitative (employee friction) and quantitative metrics
 
 ### 3. Describe Desired Future State
 
-* Map business goals to measurable outcomes
-* Translate abstract aims into KPIs or SLAs
+- Map business goals to measurable outcomes
+- Translate abstract aims into KPIs or SLAs
 
 ### 4. Identify and Categorize Gaps
 
-* Compare current vs. desired metrics
-* Categorize gaps: skill, tech, process, structural
+- Compare current vs. desired metrics
+- Categorize gaps: skill, tech, process, structural
 
 ### 5. Assess Root Causes
 
-* Use 5 Whys, Fishbone diagrams, or stakeholder workshops
+- Use 5 Whys, Fishbone diagrams, or stakeholder workshops
 
 ### 6. Prioritize
 
-* Score each gap: \[Impact × Effort × Risk Reduction]
+- Score each gap: \[Impact × Effort × Risk Reduction]
 
 ### 7. Develop Action Plans
 
-* Assign owners, define timelines, link to OKRs
+- Assign owners, define timelines, link to OKRs
 
 ### 8. Review & Validate
 
-* Schedule feedback sessions to align on root causes and fixes
+- Schedule feedback sessions to align on root causes and fixes
 
 ### 9. Finalize & Communicate
 
-* Create executive summaries, dashboards, and slides for stakeholders
+- Create executive summaries, dashboards, and slides for stakeholders
 
 ---
 
@@ -167,17 +167,17 @@ so that customers receive quicker resolutions.
 
 ### ✅ Do
 
-* Use visuals like heat maps to display gap clusters
-* Validate early with partial reviews
-* Categorize gaps and use scoring to prioritize
-* Include assumptions explicitly in a shared doc
+- Use visuals like heat maps to display gap clusters
+- Validate early with partial reviews
+- Categorize gaps and use scoring to prioritize
+- Include assumptions explicitly in a shared doc
 
 ### ❌ Don’t
 
-* Skip stakeholder interviews
-* Let ambiguity persist in KPI definitions
-* Assume legacy reports reflect real current state
-* Present final output without review loop
+- Skip stakeholder interviews
+- Let ambiguity persist in KPI definitions
+- Assume legacy reports reflect real current state
+- Present final output without review loop
 
 ---
 
@@ -226,11 +226,11 @@ so that customers receive quicker resolutions.
 
 ## Resources & References
 
-* [Gap Analysis Template – Spreadsheet](./gap-analysis-template.xlsx)
-* [Stakeholder Interview Guide](./stakeholder-interview-guide.md)
-* [KPI Mapping Table](./kpi-mapping-table.md)
-* [Scoring Model Reference](./impact-effort-risk-scorer.md)
-* [Visualization Tools – Guide](./gap-analysis-visual-aids.md)
+- [Gap Analysis Template – Spreadsheet](./gap-analysis-template.xlsx)
+- [Stakeholder Interview Guide](./stakeholder-interview-guide.md)
+- [KPI Mapping Table](./kpi-mapping-table.md)
+- [Scoring Model Reference](./impact-effort-risk-scorer.md)
+- [Visualization Tools – Guide](./gap-analysis-visual-aids.md)
 
 ---
 

--- a/01-business-analysis/requirement-gathering-guide.md
+++ b/01-business-analysis/requirement-gathering-guide.md
@@ -79,44 +79,54 @@ This guide applies to internal enterprise projects, digital initiatives, and sta
 ## Tasks & Step-by-Step Instructions
 
 ### 1. Identify Stakeholders
+
 - Map stakeholder influence and decision rights  
 - Confirm availability for elicitation sessions
 
 ### 2. Choose Elicitation Techniques
+
 - Use interviews, shadowing, surveys, observation, or workshops  
 - Combine qualitative and quantitative inputs
 
 ### 3. Prepare Questions
+
 - Use outcome-first prompts:  
   *✅ “What business problem are you trying to solve?”*  
   *❌ “Which feature do you want?”*
 
 ### 4. Conduct Sessions
+
 - Take structured notes  
 - Summarize and validate assumptions in-session  
 - Record with permission (if policy allows)
 
 ### 5. Analyze Findings
+
 - Cluster into themes: goals, constraints, must-haves, blockers  
 - Identify conflicts or gaps for follow-up
 
 ### 6. Document Requirements
+
 - Use consistent templates with acceptance criteria  
 - Separate functional vs non-functional requirements
 
 ### 7. Validate With Stakeholders
+
 - Share drafts for feedback  
 - Highlight unclear or high-impact items for review
 
 ### 8. Prioritize
+
 - Use scoring models (MoSCoW, Impact/Effort)  
 - Align on MVP vs later-phase features
 
 ### 9. Manage Changes
+
 - Implement change log with owner, impact, and timestamp  
 - Route major changes through signoff loop
 
 ### 10. Obtain Formal Signoff
+
 - Capture approvals via email or e-sign  
 - Lock the scope before build begins
 
@@ -142,7 +152,7 @@ This guide applies to internal enterprise projects, digital initiatives, and sta
 As an HR lead,  
 I want automated onboarding checklists,  
 So that new hires complete all setup tasks on time.
-````
+```
 
 ### ❌ Bad Requirement
 
@@ -167,17 +177,17 @@ So that new hires complete all setup tasks on time.
 
 ### ✅ Do
 
-* Paraphrase responses to confirm understanding
-* Map business goals to specific requirement IDs
-* Use visual workflows and mockups to clarify scope
-* Iterate with low-fidelity drafts before final signoff
+- Paraphrase responses to confirm understanding
+- Map business goals to specific requirement IDs
+- Use visual workflows and mockups to clarify scope
+- Iterate with low-fidelity drafts before final signoff
 
 ### ❌ Don’t
 
-* Skip validation rounds
-* Jump to features before defining the problem
-* Use only templates—context matters
-* Forget edge cases or regulatory scenarios
+- Skip validation rounds
+- Jump to features before defining the problem
+- Use only templates—context matters
+- Forget edge cases or regulatory scenarios
 
 ---
 
@@ -226,11 +236,11 @@ So that new hires complete all setup tasks on time.
 
 ## Resources & References
 
-* [BABOK v3 Summary](./babok-summary.md)
-* [Interview Question Bank](./elicitation-question-bank.md)
-* [Requirements Template](./standard-requirement-template.md)
-* [MoSCoW Prioritization Sheet](./moscow-prioritization-tool.xlsx)
-* [Validation Checklist](./stakeholder-signoff-checklist.md)
+- [BABOK v3 Summary](./babok-summary.md)
+- [Interview Question Bank](./elicitation-question-bank.md)
+- [Requirements Template](./standard-requirement-template.md)
+- [MoSCoW Prioritization Sheet](./moscow-prioritization-tool.xlsx)
+- [Validation Checklist](./stakeholder-signoff-checklist.md)
 
 ---
 

--- a/01-business-analysis/stakeholder-interview-checklist.md
+++ b/01-business-analysis/stakeholder-interview-checklist.md
@@ -9,49 +9,64 @@ last_reviewed: 2025-07-30
 # Stakeholder Interview Checklist
 
 ## Overview
+
 Use this checklist to structure interviews and ensure consistent information gathering from project stakeholders.
 
 ## Why It Matters
+
 Thorough interviews uncover constraints and opportunities that shape project success.
 
 ## Audience, Scope & Personas
+
 Business analysts and project leads preparing discovery sessions or kickoff meetings.
 
 ## Prerequisites
+
 Identify the right stakeholders and schedule dedicated time for discussion.
 
 ## Security & Compliance
+
 Respect privacy by storing notes securely. Redact sensitive data before sharing widely.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Prepare questions about goals, concerns, and workflows.
 2. Record responses succinctly.
 3. Confirm key points and next steps at the end of each interview.
 
 ## Access Control & Permissions
+
 Limit raw notes to the core team. Provide summarized findings to a broader audience.
 
 ## Examples & Templates
+
 ✅ Confirm expectations up front.
 ❌ Assume all stakeholders have the same priorities.
 
 ## Known Issues & Friction Points
+
 Scheduling conflicts or unclear roles may hinder progress. Address these early in the project.
 
 ## Tips & Best Practices
+
 Listen actively and clarify ambiguous statements.
 
 ## Troubleshooting
+
 If interviews stall, send follow-up questions or request a secondary contact.
 
 ## Dependencies & Escalation
+
 Coordinate with project sponsors for unresolved issues or major scope concerns.
 
 ## Success Metrics & Outcomes
+
 Comprehensive notes that guide requirement documentation and project planning.
 
 ## Resources & References
+
 Check your organization's stakeholder management guidelines.
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/01-business-analysis/story-mapping-playbook.md
+++ b/01-business-analysis/story-mapping-playbook.md
@@ -133,6 +133,7 @@ It complements epics, user stories, and release boards.
 ### ✅ MVP-focused Story Slice
 
 **Activity**: “Purchase Product”  
+
 - As a guest user, I want to add an item to cart  
 - As a guest, I want to checkout using a single payment method  
 - As a user, I want to receive an order confirmation
@@ -223,11 +224,11 @@ It complements epics, user stories, and release boards.
 
 ## Resources & References
 
-* [Jeff Patton – User Story Mapping](https://www.jpattonassociates.com/user-story-mapping/)  
-* [Miro/Mural Story Map Templates](https://miro.com/templates/user-story-map/)  
-* [Persona Mapping Guide](./persona-journey-reference.md)  
-* [Ready-for-Dev Checklist](./ready-for-development-checklist.md)  
-* [Story Prioritization Matrix](./story-prioritization-guide.md)
+- [Jeff Patton – User Story Mapping](https://www.jpattonassociates.com/user-story-mapping/)  
+- [Miro/Mural Story Map Templates](https://miro.com/templates/user-story-map/)  
+- [Persona Mapping Guide](./persona-journey-reference.md)  
+- [Ready-for-Dev Checklist](./ready-for-development-checklist.md)  
+- [Story Prioritization Matrix](./story-prioritization-guide.md)
 
 ---
 

--- a/01-business-analysis/user-acceptance-testing.md
+++ b/01-business-analysis/user-acceptance-testing.md
@@ -144,7 +144,7 @@ Invoice status changes to “Approved”; confirmation message appears.
 
 Status: ✅ Pass  
 Tester: @ashwin.finance
-````
+```
 
 ### ❌ Bad Example
 
@@ -168,18 +168,18 @@ Tester: @ashwin.finance
 
 ### ✅ Do
 
-* Use spreadsheets or UAT tools like TestRail or Zephyr
-* Assign owners for each test case
-* Tag defects with severity and feature module
-* Record feedback that’s not a bug (usability suggestions)
-* Conduct daily syncs to track progress and unblock testers
+- Use spreadsheets or UAT tools like TestRail or Zephyr
+- Assign owners for each test case
+- Tag defects with severity and feature module
+- Record feedback that’s not a bug (usability suggestions)
+- Conduct daily syncs to track progress and unblock testers
 
 ### ❌ Don’t
 
-* Use production environment for UAT
-* Let testers “figure it out”—provide scripts
-* Skip sign-off due to time pressure
-* Log bugs in chat tools—use issue trackers
+- Use production environment for UAT
+- Let testers “figure it out”—provide scripts
+- Skip sign-off due to time pressure
+- Log bugs in chat tools—use issue trackers
 
 ---
 
@@ -228,11 +228,11 @@ Tester: @ashwin.finance
 
 ## Resources & References
 
-* [UAT Planning Checklist](./uat-planning-checklist.md)
-* [Sample UAT Test Script Template](./uat-test-script-template.md)
-* [Defect Tracker Log](./uat-defect-log.xlsx)
-* [Business Sign-Off Form](./uat-signoff-form.pdf)
-* [Internal UAT Tool Guide](./uat-tooling-guide.md)
+- [UAT Planning Checklist](./uat-planning-checklist.md)
+- [Sample UAT Test Script Template](./uat-test-script-template.md)
+- [Defect Tracker Log](./uat-defect-log.xlsx)
+- [Business Sign-Off Form](./uat-signoff-form.pdf)
+- [Internal UAT Tool Guide](./uat-tooling-guide.md)
 
 ---
 

--- a/01-business-analysis/user-story-templates.md
+++ b/01-business-analysis/user-story-templates.md
@@ -76,7 +76,7 @@ Use the standard format:
 As a [role],  
 I want to [action/goal],  
 So that [desired outcome].
-````
+```
 
 Example:
 
@@ -90,9 +90,9 @@ So that only authorized users can access sensitive data.
 
 Use bullet points or behavior-driven format:
 
-* ✅ User can select roles from a dropdown
-* ✅ Unauthorized access attempts are logged
-* ✅ System restricts views based on assigned roles
+- ✅ User can select roles from a dropdown
+- ✅ Unauthorized access attempts are logged
+- ✅ System restricts views based on assigned roles
 
 Or use Gherkin-style:
 
@@ -104,9 +104,9 @@ Then they see an "Access Denied" message
 
 ### 3. Review with Team
 
-* Confirm clarity, feasibility, and testability
-* Link to design mocks, user flows, or relevant documentation
-* Update based on team feedback before marking ready-for-dev
+- Confirm clarity, feasibility, and testability
+- Link to design mocks, user flows, or relevant documentation
+- Update based on team feedback before marking ready-for-dev
 
 ---
 
@@ -134,9 +134,9 @@ So that I can regain account access securely.
 
 **Acceptance Criteria**
 
-* User receives a reset email within 2 minutes
-* Link expires after 24 hours
-* Must include captcha to prevent abuse
+- User receives a reset email within 2 minutes
+- Link expires after 24 hours
+- Must include captcha to prevent abuse
 
 ---
 
@@ -162,18 +162,18 @@ So that I can regain account access securely.
 
 ### ✅ Do
 
-* Focus on one action per story
-* Use real roles (not "the system")
-* Validate acceptance criteria with QA
-* Link to mockups or data models if needed
-* Keep language accessible—avoid jargon
+- Focus on one action per story
+- Use real roles (not "the system")
+- Validate acceptance criteria with QA
+- Link to mockups or data models if needed
+- Keep language accessible—avoid jargon
 
 ### ❌ Don’t
 
-* Include backend-only requirements here (track in technical tasks)
-* Write stories that bundle multiple outcomes
-* Use unclear verbs like “improve,” “optimize,” “support”
-* Skip user benefit or business value
+- Include backend-only requirements here (track in technical tasks)
+- Write stories that bundle multiple outcomes
+- Use unclear verbs like “improve,” “optimize,” “support”
+- Skip user benefit or business value
 
 ---
 
@@ -222,11 +222,11 @@ So that I can regain account access securely.
 
 ## Resources & References
 
-* [Agile Alliance – User Stories](https://www.agilealliance.org/agile101/user-stories/)
-* [Scrum Guide](https://scrumguides.org/scrum-guide.html)
-* [Story Mapping Playbook](./user-story-mapping-guide.md)
-* [Acceptance Criteria Guide](./acceptance-criteria-reference.md)
-* [Ready-for-Dev Checklist](./ready-for-development-checklist.md)
+- [Agile Alliance – User Stories](https://www.agilealliance.org/agile101/user-stories/)
+- [Scrum Guide](https://scrumguides.org/scrum-guide.html)
+- [Story Mapping Playbook](./user-story-mapping-guide.md)
+- [Acceptance Criteria Guide](./acceptance-criteria-reference.md)
+- [Ready-for-Dev Checklist](./ready-for-development-checklist.md)
 
 ---
 

--- a/02-strategic-change-communications/AGENTS.md
+++ b/02-strategic-change-communications/AGENTS.md
@@ -1,11 +1,13 @@
 # AGENTS.md – Enterprise Change Communications
 
 ## 📌 General Instructions
+
 - Clear, engaging, human-centric tone.
 - Use strategic storytelling to drive engagement.
 - Maintain simplicity; avoid jargon.
 
 ## 🗂️ Required Structure
+
 1. Overview (Clear rationale for communication)
 2. Importance & Organizational Context
 3. Target Audience & Personas
@@ -21,21 +23,25 @@
 13. Last Updated
 
 ## 🎯 Formatting Guidelines
+
 - Concise bullet points, clearly formatted checklists.
 - Clearly marked examples of effective communication.
 
 ## 🚩 Commit & PR Standards
+
 - Highlight strategic communication benefits clearly.
 - Explicitly document communication security adherence in PR.
 
 ## 🔐 Security & Confidentiality
+
 - Include clearly marked confidentiality and distribution instructions.
 - Adhere explicitly to enterprise data protection guidelines.
 
 ## 📊 Validation & Checks
+
 - Validate messaging clarity explicitly.
 - Confirm compliance with organizational communication standards.
 
 ## 🔄 Document Review
-- Regular quarterly reviews or aligned with organizational change cycles.
 
+- Regular quarterly reviews or aligned with organizational change cycles.

--- a/02-strategic-change-communications/README.md
+++ b/02-strategic-change-communications/README.md
@@ -1,44 +1,56 @@
 # 02-Strategic Change Communications
 
 ## Overview
+
 - Present frameworks for managing and explaining change.
 
 ## Importance & Organizational Context
+
 - Consistent messaging helps employees embrace new processes.
 
 ## Target Audience & Personas
+
 - Communications teams and project leaders.
 
 ## Communication Prerequisites & Readiness
+
 - Confirm leadership alignment and define key messages before rollout.
 
 ## Security & Confidentiality Guidelines
+
 - Mark drafts confidential and share only with approved stakeholders.
 
 ## Step-by-Step Communication Instructions
+
 1. Outline objectives and success metrics.
 2. Choose channels and create a rollout calendar.
 3. Gather feedback and adjust messaging.
 
 ## Clear Messaging Examples & Templates
+
 ✅ "This update simplifies your workflow."
 ❌ "The system will change, figure it out."
 
 ## Known Communication Risks & Mitigation
+
 - Employees may feel uninformed; provide frequent updates.
 
 ## Best Practices & Strategic Tips
+
 - Use storytelling to connect change with business vision.
 
 ## Escalation Path & Dependencies
+
 - Route complex questions through project sponsors.
 
 ## Metrics & Success Indicators
+
 - Survey scores and adoption rates improve after communication.
 
 ## Supporting Resources & Contacts
+
 - Style guide, channel matrix, contact list.
 
 ## Last Updated
-2025-07-30
 
+2025-07-30

--- a/03-technical-communication-documentation/AGENTS.md
+++ b/03-technical-communication-documentation/AGENTS.md
@@ -1,10 +1,12 @@
 # AGENTS.md – Technical Documentation Standards
 
 ## 📌 General Instructions
+
 - Precise, consistent, developer-friendly voice.
 - Structured content clearly aligned with technical standards.
 
 ## 🗂️ Required Structure
+
 1. Overview & Technical Context
 2. Importance & Technical Value
 3. Audience & Technical Personas
@@ -21,21 +23,25 @@
 14. Last Reviewed & Updated
 
 ## 🛠️ Formatting Rules
+
 - Use markdown clearly structured for technical readability.
 - Explicit code blocks, command-line examples clearly formatted.
 
 ## 🚩 Commit & PR Guidelines
+
 - Clearly summarize technical changes.
 - Explicitly document security and compliance review.
 
 ## 🔐 Security Guidelines
+
 - Clearly document recommended security configurations.
 - Define explicit data privacy and compliance guidelines.
 
 ## 📊 Validation Checks
+
 - Validate against markdownlint explicitly.
 - Technical correctness validation explicitly stated.
 
 ## 🔄 Review Cycle
-- Reviewed clearly every quarter or technical releases.
 
+- Reviewed clearly every quarter or technical releases.

--- a/03-technical-communication-documentation/README.md
+++ b/03-technical-communication-documentation/README.md
@@ -1,46 +1,59 @@
 # 03-Technical Communication Documentation
 
 ## Overview & Technical Context
+
 - Provide clear developer-facing documents for APIs and workflows.
 
 ## Importance & Technical Value
+
 - Well-structured docs reduce onboarding time and support tickets.
 
 ## Audience & Technical Personas
+
 - Developers, technical writers, and system integrators.
 
 ## Technical Prerequisites
+
 - Knowledge of repository structure and access rights.
 
 ## Security, Data Handling & Compliance
+
 - Avoid embedding credentials. Follow internal security policy.
 
 ## Detailed Step-by-Step Technical Instructions
+
 1. Clone the repository.
 2. Review API endpoints in `docs/`.
 3. Submit improvement requests through pull requests.
 
 ## Practical Technical Examples & Templates
+
 - See sample code snippets in `/assets/diagrams` for architecture.
 
 ## Known Issues & Technical Friction Points
+
 - Outdated dependencies can cause build failures.
 
 ## Technical Best Practices
+
 - Use consistent naming conventions and automated linting.
 
 ## Troubleshooting & Debugging
+
 - Check CI logs in `.github/workflows` for errors.
 
 ## Dependencies & Escalation Paths
+
 - Contact the DevOps team for CI/CD issues.
 
 ## Technical Metrics & Success Outcomes
+
 - Reduced bug reports and faster release cycles.
 
 ## Resources & Technical References
+
 - Internal API portal, coding standards wiki.
 
 ## Last Reviewed & Updated
-2025-07-30
 
+2025-07-30

--- a/04-ai-contentops-workflows/AGENTS.md
+++ b/04-ai-contentops-workflows/AGENTS.md
@@ -1,10 +1,12 @@
 # AGENTS.md – AI & ContentOps Standards
 
 ## 📌 General Instructions
+
 - Use precise, actionable, clear AI-focused language.
 - Clearly document assumptions around AI workflows, tools, and limitations.
 
 ## 🗂️ Required Structure
+
 1. AI Workflow Overview
 2. Importance & AI Integration Impact
 3. Intended Audience & AI Personas
@@ -20,21 +22,25 @@
 13. Last Updated
 
 ## 🤖 Formatting & Style
+
 - Clearly structured markdown, task-based approach.
 - Explicit AI-driven examples and clearly formatted prompts.
 
 ## 🚩 Commit & PR Guidelines
+
 - Document clearly how AI workflows improve productivity or quality.
 - Confirm explicit AI compliance and ethical standards adherence.
 
 ## 🔐 Security & Ethics
+
 - Explicitly define AI ethics considerations and security standards (GDPR, data privacy).
 - Clearly articulate data-handling guidelines for AI workflows.
 
 ## 📊 Validation & Checks
+
 - Explicit markdownlint checks.
 - AI workflows validation and review clearly documented.
 
 ## 🔄 Document Updates
-- Regularly every quarter or with significant AI-tooling updates.
 
+- Regularly every quarter or with significant AI-tooling updates.

--- a/04-ai-contentops-workflows/README.md
+++ b/04-ai-contentops-workflows/README.md
@@ -1,44 +1,56 @@
 # 04-AI ContentOps Workflows
 
 ## AI Workflow Overview
+
 - Outline how prompts and automation improve content delivery.
 
 ## Importance & AI Integration Impact
+
 - Increases consistency and speed of documentation updates.
 
 ## Intended Audience & AI Personas
+
 - Content strategists and automation engineers.
 
 ## Prerequisites & Environment Setup
+
 - Python 3.10 and API keys stored securely.
 
 ## AI Ethics, Security & Compliance
+
 - Do not store user data in training sets without consent.
 
 ## Step-by-Step AI & Automation Tasks
+
 1. Build prompt templates.
 2. Test with small datasets.
 3. Deploy automation through CI workflows.
 
 ## AI & Prompt Engineering Examples
+
 ✅ Structured prompts with context.
 ❌ Vague commands without target outputs.
 
 ## Known AI Issues & Mitigation
+
 - Bias in training data; review outputs for fairness.
 
 ## Best Practices & AI Optimization Tips
+
 - Log prompt results to refine performance.
 
 ## Dependencies, Limitations & Escalation Paths
+
 - Escalate API errors to the AI team.
 
 ## Measurable Outcomes & AI Metrics
+
 - Reduced manual editing time per document.
 
 ## AI Tools, Resources & References
+
 - OpenAI API docs, LangChain examples.
 
 ## Last Updated
-2025-07-30
 
+2025-07-30

--- a/05-automation-ci-cd/AGENTS.md
+++ b/05-automation-ci-cd/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS.md – CI/CD Automation Standards
 
 ## 📌 General Instructions
+
 - Clear, structured language explicitly targeting DevOps & automation teams.
 
 ## 🗂️ Required Structure
+
 1. Automation Workflow Overview
 2. Importance & CI/CD Benefits
 3. Target Audience (DevOps, Developers)
@@ -20,20 +22,24 @@
 14. Last Reviewed / Updated
 
 ## ⚙️ Formatting Rules
+
 - Explicit markdown structure for CI/CD tasks.
 - Clear command examples and configurations.
 
 ## 🚩 Commit & PR Guidelines
+
 - Clear automation improvements explicitly stated.
 - Confirm security standards adherence explicitly.
 
 ## 🔐 Security & Compliance
+
 - Clearly documented automated workflow security recommendations.
 
 ## 📊 Validation Checks
+
 - Explicit markdownlint validation.
 - Confirm automation workflow testing clearly.
 
 ## 🔄 Review Cycle
-- Reviewed quarterly or with significant workflow changes.
 
+- Reviewed quarterly or with significant workflow changes.

--- a/05-automation-ci-cd/README.md
+++ b/05-automation-ci-cd/README.md
@@ -1,46 +1,59 @@
 # 05-Automation CI/CD
 
 ## Automation Workflow Overview
+
 - Scripts and pipelines streamline documentation builds.
 
 ## Importance & CI/CD Benefits
+
 - Continuous testing reduces manual errors and speeds releases.
 
 ## Target Audience (DevOps, Developers)
+
 - DevOps engineers and contributors managing deployments.
 
 ## Environment & Prerequisites
+
 - GitHub account with workflow permissions.
 
 ## Security & Compliance in Automation
+
 - Store secrets in encrypted variables and audit access.
 
 ## Step-by-Step Automation Tasks
+
 1. Run `scripts/setup-environment.sh` to install tools.
 2. Commit changes and push to trigger CI.
 3. Review build results in GitHub Actions.
 
 ## Explicit Workflow Examples & Templates
+
 - See `.github/workflows/ci-build.yml` for a minimal build job.
 
 ## Known Automation Issues & Mitigation
+
 - Missing dependencies cause build failures; run `setup-environment.sh` first.
 
 ## Automation Best Practices
+
 - Keep workflows simple and version-controlled.
 
 ## Troubleshooting Automation
+
 - Check job logs in the Actions tab.
 
 ## Dependencies & Escalation
+
 - Contact the automation team if builds fail consistently.
 
 ## Automation Success Metrics & Outcomes
+
 - Faster deployments and fewer rollback incidents.
 
 ## Resources & Tooling References
+
 - GitHub Actions docs, shell scripting guides.
 
 ## Last Reviewed / Updated
-2025-07-30
 
+2025-07-30

--- a/06-comms-and-content-enablement/AGENTS.md
+++ b/06-comms-and-content-enablement/AGENTS.md
@@ -1,11 +1,13 @@
 # AGENTS.md – Comms and Content Enablement Standards
 
 ## 📌 Guidance
+
 - Keep guidance concise and action oriented.
 - Focus on intranet design systems, editorial workflows, and enablement templates.
 - Use second-person voice and avoid jargon.
 
 ## 🗂️ Required Structure
+
 1. Overview of the enablement asset
 2. Why it improves internal communications
 3. Target Audience & Stakeholders
@@ -21,6 +23,6 @@
 13. Last Reviewed / Updated
 
 ## 🔄 Review Cycle
+
 - Align with global AGENTS guidelines.
 - Review quarterly or when communication tooling changes.
-

--- a/06-comms-and-content-enablement/change-readiness-assessment.md
+++ b/06-comms-and-content-enablement/change-readiness-assessment.md
@@ -111,7 +111,7 @@ Before deploying these templates:
 | Willingness & Motivation   | HR                   | Medium (60%)     | High willingness, but unclear on what's expected post-launch                 |
 | Cultural Alignment         | Engineering          | High (90%)       | Team used to agile rollouts; positive sentiment observed                     |
 | Past Change Experience     | Operations           | Low (35%)        | Negative history with ERP migration; team skeptical about promises made      |
-````
+```
 
 ### ❌ Poor Practice
 
@@ -172,6 +172,7 @@ DM me or reply here—thanks!
 ```
 
 Use this informal check-in message to prompt feedback from medium-impact stakeholder groups (Tier 2 or 3).
+
 ```markdown
 📢 Change Readiness Check-In – [Project Name]
 
@@ -220,11 +221,11 @@ Thanks,
 
 ## Tips & Best Practices
 
-* Use consistent rating scales across all tools
-* Keep templates lightweight and editable
-* Mix methods (quant + qual) to get full picture
-* Share back insights quickly to build feedback loops
-* Create role-specific prompts (e.g., for leadership vs. delivery teams)
+- Use consistent rating scales across all tools
+- Keep templates lightweight and editable
+- Mix methods (quant + qual) to get full picture
+- Share back insights quickly to build feedback loops
+- Create role-specific prompts (e.g., for leadership vs. delivery teams)
 
 ---
 
@@ -268,11 +269,11 @@ Thanks,
 
 ## Resources & References
 
-* [Change Readiness Assessment](./change-readiness-assessment.md)
-* [Internal Survey Guide](./internal-survey-guide.md)
-* [Communication Metrics Dashboard](./communication-metrics-dashboard.md)
-* [Executive Briefing Template](./executive-briefing-template.md)
-* [Stakeholder Engagement Guide](./stakeholder-engagement-guide.md)
+- [Change Readiness Assessment](./change-readiness-assessment.md)
+- [Internal Survey Guide](./internal-survey-guide.md)
+- [Communication Metrics Dashboard](./communication-metrics-dashboard.md)
+- [Executive Briefing Template](./executive-briefing-template.md)
+- [Stakeholder Engagement Guide](./stakeholder-engagement-guide.md)
 
 ---
 

--- a/06-comms-and-content-enablement/communication-matrix-template.md
+++ b/06-comms-and-content-enablement/communication-matrix-template.md
@@ -51,10 +51,12 @@ It transforms messaging into a strategic layer of operational success.
 ### Scope
 
 Applies to:
+
 - Internal programs, policy launches, product rollouts, process updates
 - Departmental or enterprise-level change initiatives
 
 Not intended for:
+
 - External PR campaigns or one-off tactical communications
 
 ---
@@ -90,7 +92,7 @@ Examples:
 - Ensure 95% onboarding completion by [Date]
 - Reduce policy-related support tickets by 40%
 - Inform frontline teams of tool deprecation before [Go-live]
-````
+```
 
 ---
 
@@ -98,10 +100,10 @@ Examples:
 
 Group recipients by:
 
-* Impact tier (high, medium, low)
-* Function (Exec, Team Lead, Staff)
-* Region or language
-* Channel familiarity (Slack, intranet, email, etc.)
+- Impact tier (high, medium, low)
+- Function (Exec, Team Lead, Staff)
+- Region or language
+- Channel familiarity (Slack, intranet, email, etc.)
 
 ---
 
@@ -133,9 +135,9 @@ Choose based on urgency and visibility:
 
 Each item in your matrix should include:
 
-* Content creator
-* Channel publisher
-* Final approver (e.g., Legal, HR, Sponsor)
+- Content creator
+- Channel publisher
+- Final approver (e.g., Legal, HR, Sponsor)
 
 ---
 
@@ -189,11 +191,11 @@ Use the editable table format below.
 
 ## Tips & Best Practices
 
-* Use consistent formatting for channel cadence (e.g., every Friday 3PM)
-* Time messages with key milestones or system changes
-* Include escalation paths for failed or delayed comms
-* Log message versions and attachments for reuse or audits
-* Regularly validate audience groups with department leads
+- Use consistent formatting for channel cadence (e.g., every Friday 3PM)
+- Time messages with key milestones or system changes
+- Include escalation paths for failed or delayed comms
+- Log message versions and attachments for reuse or audits
+- Regularly validate audience groups with department leads
 
 ---
 
@@ -212,10 +214,10 @@ Use the editable table format below.
 
 ### Key Dependencies
 
-* Stakeholder engagement guide
-* Comms calendar from project plan
-* Finalized core messaging from change sponsor
-* Available comms tools and distribution lists
+- Stakeholder engagement guide
+- Comms calendar from project plan
+- Finalized core messaging from change sponsor
+- Available comms tools and distribution lists
 
 ### Risks
 
@@ -241,12 +243,12 @@ Use the editable table format below.
 
 ## Resources & References
 
-* [Stakeholder Engagement Guide](./stakeholder-engagement-guide.md)
-* [Change Readiness Toolkit](./change-readiness-assessment.md)
-* [Policy Comms Template](./policy-update-notification.md)
-* [Internal Newsletter Planning Guide](./internal-newsletter-guide.md)
-* [Prosci ADKAR® Framework](https://www.prosci.com/adkar)
-* [PMI Communications Planning](https://www.pmi.org/pmbok-guide-standards)
+- [Stakeholder Engagement Guide](./stakeholder-engagement-guide.md)
+- [Change Readiness Toolkit](./change-readiness-assessment.md)
+- [Policy Comms Template](./policy-update-notification.md)
+- [Internal Newsletter Planning Guide](./internal-newsletter-guide.md)
+- [Prosci ADKAR® Framework](https://www.prosci.com/adkar)
+- [PMI Communications Planning](https://www.pmi.org/pmbok-guide-standards)
 
 ---
 

--- a/06-comms-and-content-enablement/executive-briefing-template.md
+++ b/06-comms-and-content-enablement/executive-briefing-template.md
@@ -117,7 +117,7 @@ PURPOSE: [Awareness / Decision / Escalation]
 6. Resources & References  
 - [Dashboard]  
 - [Risk Register or Link to Plan]
-````
+```
 
 ---
 
@@ -169,11 +169,11 @@ PURPOSE: [Awareness / Decision / Escalation]
 
 ## Tips & Best Practices
 
-* **Think like an executive**: What’s the decision or risk they need to see?
-* **Write tight**: Every section should be skimmable in under 10 seconds.
-* **Anticipate questions**: Include rationale and optional appendix links.
-* **Use bolding for key phrases**: e.g., “Launch Delay Risk = \$120K”
-* **Pre-brief aides when needed**: Avoid surprises in exec reviews.
+- **Think like an executive**: What’s the decision or risk they need to see?
+- **Write tight**: Every section should be skimmable in under 10 seconds.
+- **Anticipate questions**: Include rationale and optional appendix links.
+- **Use bolding for key phrases**: e.g., “Launch Delay Risk = \$120K”
+- **Pre-brief aides when needed**: Avoid surprises in exec reviews.
 
 ---
 
@@ -193,16 +193,16 @@ PURPOSE: [Awareness / Decision / Escalation]
 
 ### Dependencies
 
-* PMO for timeline and ownership confirmation
-* Internal Comms for language and formatting
-* Legal/Finance for compliance-sensitive updates
-* Data/Analytics for validated metrics
+- PMO for timeline and ownership confirmation
+- Internal Comms for language and formatting
+- Legal/Finance for compliance-sensitive updates
+- Data/Analytics for validated metrics
 
 ### Escalation Path
 
-* Unclear approvals → escalate via Chief of Staff
-* Decision delay → flag in leadership sync deck
-* Stakeholder misalignment → pre-brief or schedule 1:1 review
+- Unclear approvals → escalate via Chief of Staff
+- Decision delay → flag in leadership sync deck
+- Stakeholder misalignment → pre-brief or schedule 1:1 review
 
 ---
 
@@ -220,12 +220,12 @@ PURPOSE: [Awareness / Decision / Escalation]
 
 ## Resources & References
 
-* [Communication Matrix Template](./communication-matrix-template.md)
-* [Change Readiness Toolkit](./change-readiness-assessment.md)
-* [Internal Style Guide Snippets](../08-style-guides/writing-principles.md)
-* [Leadership Messaging Guide](./leadership-update-template.md)
-* [Barbara Minto’s Pyramid Principle](https://www.amazon.com/Pyramid-Principle-Logic-Writing-Thinking/dp/0273710515)
-* [PMI Executive Communication Guide](https://www.pmi.org)
+- [Communication Matrix Template](./communication-matrix-template.md)
+- [Change Readiness Toolkit](./change-readiness-assessment.md)
+- [Internal Style Guide Snippets](../08-style-guides/writing-principles.md)
+- [Leadership Messaging Guide](./leadership-update-template.md)
+- [Barbara Minto’s Pyramid Principle](https://www.amazon.com/Pyramid-Principle-Logic-Writing-Thinking/dp/0273710515)
+- [PMI Executive Communication Guide](https://www.pmi.org)
 
 ---
 

--- a/06-comms-and-content-enablement/hybrid-rollout-guide.md
+++ b/06-comms-and-content-enablement/hybrid-rollout-guide.md
@@ -136,7 +136,7 @@ Not included: performance reviews, tax compliance, or legal jurisdictional guida
 📌 **Hybrid Policy: Flexible**
 
 Employees may work from home up to 3 days/week. Each team defines a fixed collaboration day in-office. Productivity will be measured by deliverables, not time logged. Remote setups must comply with IT standards.
-````
+```
 
 ### ❌ vs ✅ Hybrid Meeting Behavior
 
@@ -162,12 +162,12 @@ Employees may work from home up to 3 days/week. Each team defines a fixed collab
 
 ## Tips & Best Practices
 
-* Anchor rollout in **flexibility, equity, and clarity**
-* Share leadership hybrid schedules to set tone
-* Provide an “opt-in” grace period to reduce fear
-* Track both **tool usage** and **employee feedback**
-* Normalize **asynchronous workflows** (not just hybrid meetings)
-* Reinforce “one company, multiple locations” in culture decks
+- Anchor rollout in **flexibility, equity, and clarity**
+- Share leadership hybrid schedules to set tone
+- Provide an “opt-in” grace period to reduce fear
+- Track both **tool usage** and **employee feedback**
+- Normalize **asynchronous workflows** (not just hybrid meetings)
+- Reinforce “one company, multiple locations” in culture decks
 
 ---
 
@@ -186,10 +186,10 @@ Employees may work from home up to 3 days/week. Each team defines a fixed collab
 
 ### Dependencies
 
-* Cross-functional buy-in from HR, IT, Legal, Comms, and Finance
-* Physical space retrofits completed before launch
-* Hybrid collaboration tools deployed org-wide
-* Governance group to monitor compliance and sentiment
+- Cross-functional buy-in from HR, IT, Legal, Comms, and Finance
+- Physical space retrofits completed before launch
+- Hybrid collaboration tools deployed org-wide
+- Governance group to monitor compliance and sentiment
 
 ### Risks & Escalation
 
@@ -215,14 +215,14 @@ Employees may work from home up to 3 days/week. Each team defines a fixed collab
 
 ## Resources & References
 
-* [Communication Matrix Template](./communication-matrix-template.md)
-* [Feedback Collection Process](./feedback-collection-process.md)
-* [Policy Update Notification](../01-internal-communications/policy-update-notification.md)
-* [Internal Survey Guide](../01-internal-communications/internal-survey-guide.md)
-* [Communication Metrics Dashboard](../01-internal-communications/communication-metrics-dashboard.md)
-* [Microsoft WorkLab](https://www.microsoft.com/en-us/worklab)
-* [Google Workspace – Hybrid Resources](https://workspace.google.com/resources/hybrid-work/)
-* [HBR – The Definitive Guide to Hybrid Work](https://hbr.org/2021/05/the-definitive-guide-to-hybrid-work)
+- [Communication Matrix Template](./communication-matrix-template.md)
+- [Feedback Collection Process](./feedback-collection-process.md)
+- [Policy Update Notification](../01-internal-communications/policy-update-notification.md)
+- [Internal Survey Guide](../01-internal-communications/internal-survey-guide.md)
+- [Communication Metrics Dashboard](../01-internal-communications/communication-metrics-dashboard.md)
+- [Microsoft WorkLab](https://www.microsoft.com/en-us/worklab)
+- [Google Workspace – Hybrid Resources](https://workspace.google.com/resources/hybrid-work/)
+- [HBR – The Definitive Guide to Hybrid Work](https://hbr.org/2021/05/the-definitive-guide-to-hybrid-work)
 
 ---
 
@@ -231,4 +231,3 @@ Employees may work from home up to 3 days/week. Each team defines a fixed collab
 **Date:** 2025-07-30
 **Maintainer:** HR & People Operations / Shailesh Rawat
 **Status:** ✅ Stable | Version 1.0 – Aligned with rollout framework and RBAC integration
-

--- a/06-comms-and-content-enablement/org-wide-policy-change.md
+++ b/06-comms-and-content-enablement/org-wide-policy-change.md
@@ -85,16 +85,19 @@ Before initiating the communication rollout:
 ## Tasks & Step-by-Step Instructions
 
 ### 1. Draft Unified Messaging
+
 - Clarify the intent: “What’s changing and why?”
 - Define stakeholder-specific impact statements
 - Use plain language alongside legal phrasing
 
 ### 2. Select Delivery Mechanisms
+
 - Primary: Company-wide email or leadership broadcast  
 - Secondary: Intranet update, internal Slack/Teams post, FAQ page  
 - Tertiary: Live session, async training module, manager cascade  
 
 ### 3. Execute Communication Rollout
+
 - Send official announcement with summary and link to full policy  
 - Upload latest policy to a versioned document system  
 - Add visual summaries (carousel, one-pager) for non-legal users  
@@ -102,6 +105,7 @@ Before initiating the communication rollout:
 - Share response form or comment-enabled page  
 
 ### 4. Reinforce & Monitor
+
 - Track acknowledgment via LMS or e-sign tools  
 - Collect feedback and flag unresolved queries  
 - Escalate delays in acknowledgment via manager nudge loop
@@ -138,7 +142,7 @@ We’ve updated our **Data Usage Policy** to reflect new compliance requirements
 
 Thanks,  
 Head of Compliance
-````
+```
 
 ### ❌ Bad Example: Legalese Dump
 
@@ -162,17 +166,17 @@ Head of Compliance
 
 ### ✅ Do
 
-* Localize messaging for non-native readers
-* Use visuals to aid comprehension
-* Embed call-to-actions (CTA) within the message body
-* Treat managers as change partners, not just recipients
+- Localize messaging for non-native readers
+- Use visuals to aid comprehension
+- Embed call-to-actions (CTA) within the message body
+- Treat managers as change partners, not just recipients
 
 ### ❌ Don’t
 
-* Assume one-time communication is enough
-* Use emails only—combine formats
-* Share policy PDFs without summaries or context
-* Skip feedback loops
+- Assume one-time communication is enough
+- Use emails only—combine formats
+- Share policy PDFs without summaries or context
+- Skip feedback loops
 
 ---
 
@@ -222,11 +226,11 @@ Head of Compliance
 
 ## Resources & References
 
-* [Internal Comms: Policy Rollout Template](./policy-update-notification.md)
-* [Feedback Form Template](./feedback-collection-process.md)
-* [Acknowledgment Tracker](./acknowledgment-tracker.md)
-* [Security Checklist](./security-policy-checklist.md)
-* [Change Readiness Assessment Guide](./change-readiness-assessment.md)
+- [Internal Comms: Policy Rollout Template](./policy-update-notification.md)
+- [Feedback Form Template](./feedback-collection-process.md)
+- [Acknowledgment Tracker](./acknowledgment-tracker.md)
+- [Security Checklist](./security-policy-checklist.md)
+- [Change Readiness Assessment Guide](./change-readiness-assessment.md)
 
 ---
 
@@ -238,4 +242,3 @@ Head of Compliance
 **Status:** ✅ Stable
 
 ---
-

--- a/06-comms-and-content-enablement/risk-mitigation-plan.md
+++ b/06-comms-and-content-enablement/risk-mitigation-plan.md
@@ -120,7 +120,7 @@ It does **not** replace legal risk assessments, investor disclosures, or insuran
 | Key system offline during rollout   | Technical    | High (5)   | High   | Full simulation + fallback environment       | IT Lead      | Active   |
 | Low engagement from team leads      | Operational  | Medium (3) | High   | 1:1 cascade briefing + Slack reminders       | Comms Manager| Planned  |
 | Policy ambiguity                    | Compliance   | Low (2)    | High   | Legal review + clarification comms           | Legal Team   | Resolved |
-````
+```
 
 ---
 
@@ -153,17 +153,17 @@ It does **not** replace legal risk assessments, investor disclosures, or insuran
 
 ✅ Do:
 
-* Embed risk updates into weekly standups or retrospectives
-* Use tags like `#showstopper`, `#P1`, `#cross-functional`
-* Update statuses consistently, even if nothing changed
-* Share a summary view for execs (3–5 key risks only)
+- Embed risk updates into weekly standups or retrospectives
+- Use tags like `#showstopper`, `#P1`, `#cross-functional`
+- Update statuses consistently, even if nothing changed
+- Share a summary view for execs (3–5 key risks only)
 
 ❌ Don’t:
 
-* Let vague risks stay in the log without action steps
-* Assume teams will flag blockers unless prompted
-* Wait for risks to materialize before starting conversations
-* Bury high-risk items in long documents—highlight and flag
+- Let vague risks stay in the log without action steps
+- Assume teams will flag blockers unless prompted
+- Wait for risks to materialize before starting conversations
+- Bury high-risk items in long documents—highlight and flag
 
 ---
 
@@ -213,11 +213,11 @@ It does **not** replace legal risk assessments, investor disclosures, or insuran
 
 ## Resources & References
 
-* [Change Readiness Assessment](./change-readiness-assessment.md)
-* [Executive Briefing Template](./executive-briefing-template.md)
-* [Communication Matrix Template](./communication-matrix-template.md)
-* [Feedback Collection Process](./feedback-collection-process.md)
-* [Training Materials Guide](./training-materials-guide.md)
+- [Change Readiness Assessment](./change-readiness-assessment.md)
+- [Executive Briefing Template](./executive-briefing-template.md)
+- [Communication Matrix Template](./communication-matrix-template.md)
+- [Feedback Collection Process](./feedback-collection-process.md)
+- [Training Materials Guide](./training-materials-guide.md)
 
 ---
 
@@ -226,4 +226,3 @@ It does **not** replace legal risk assessments, investor disclosures, or insuran
 **Date:** 2025-07-30
 **Maintainer:** Shailesh Rawat (PoeticMayhem)
 **Status:** ✅ Stable | Version 1.0
-

--- a/06-comms-and-content-enablement/stakeholder-communication-plan.md
+++ b/06-comms-and-content-enablement/stakeholder-communication-plan.md
@@ -102,7 +102,7 @@ Use a matrix to segment stakeholders:
 | Team Leads        | Enablers       | Townhall + Slack  | Training + Milestone    | Weekly       | Change Manager   |
 | End Users         | Receivers      | Email + Dashboard | Instruction + FAQ       | As needed    | Internal Comms   |
 | Legal Team        | Validator      | Email + Docs      | Policy Brief + Risk     | Milestone    | Compliance Lead  |
-````
+```
 
 ---
 
@@ -180,17 +180,17 @@ Let us know if you have questions,
 
 ✅ Do:
 
-* Align message timing with rollout milestones
-* Use stakeholder-specific formats (dashboards for execs, videos for staff)
-* Pre-brief resistors or high-risk teams before announcements
-* Share weekly updates with visible progress indicators
+- Align message timing with rollout milestones
+- Use stakeholder-specific formats (dashboards for execs, videos for staff)
+- Pre-brief resistors or high-risk teams before announcements
+- Share weekly updates with visible progress indicators
 
 ❌ Don’t:
 
-* Assume email = communication
-* Use same message for all audiences
-* Send updates without listing action items
-* Neglect the feedback loop or stakeholder visibility
+- Assume email = communication
+- Use same message for all audiences
+- Send updates without listing action items
+- Neglect the feedback loop or stakeholder visibility
 
 ---
 
@@ -209,10 +209,10 @@ Let us know if you have questions,
 
 ### Dependencies
 
-* Stakeholder mapping and impact analysis
-* Approved messaging calendar and content
-* Channel readiness (e.g., access to Slack/email groups)
-* Clear project phase handovers
+- Stakeholder mapping and impact analysis
+- Approved messaging calendar and content
+- Channel readiness (e.g., access to Slack/email groups)
+- Clear project phase handovers
 
 ### Escalation Path
 
@@ -238,11 +238,11 @@ Let us know if you have questions,
 
 ## Resources & References
 
-* [Communication Matrix Template](./communication-matrix-template.md)
-* [Executive Briefing Template](./executive-briefing-template.md)
-* [Change Readiness Assessment Toolkit](./change-readiness-assessment.md)
-* [Feedback Collection Framework](./feedback-collection-process.md)
-* [Training Materials Guide](./training-materials-guide.md)
+- [Communication Matrix Template](./communication-matrix-template.md)
+- [Executive Briefing Template](./executive-briefing-template.md)
+- [Change Readiness Assessment Toolkit](./change-readiness-assessment.md)
+- [Feedback Collection Framework](./feedback-collection-process.md)
+- [Training Materials Guide](./training-materials-guide.md)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Always begin with a YAML frontmatter that includes: `title`, `archetype`, `statu
 - Explicit placeholders for visual elements (images, diagrams)
 - Avoid long paragraphs; clearly prefer bulleted lists or tables
 
-### Enhance your markdown output to follow the following UX rules:
+### Enhance your markdown output to follow the following UX rules
+
 - Use markdown tables wherever roles, outcomes, or comparisons exist
 - Include ✅/❌ do/don’t lists where applicable
 - Use code blocks for all reusable templates or formatting examples
@@ -108,4 +109,3 @@ Always begin with a YAML frontmatter that includes: `title`, `archetype`, `statu
 - Clearly articulates the relationship between top-level rules and nested exceptions.
 
 ---
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,57 +1,74 @@
 # CHANGELOG
 
 ## Overview
+
 This file summarizes notable updates to the repository in reverse
 chronological order.
 
 ## Why It Matters
+
 A clear changelog helps users understand new features, fixes and documentation
 improvements.
 
 ## Audience, Scope & Personas
+
 - Contributors tracking project history
 - Stakeholders reviewing recent changes
 
 ## Prerequisites
+
 - None
 
 ## Security, Compliance & Privacy
+
 Dates and descriptions must not expose sensitive information. Keep entries
 concise.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Add a new heading with the date of your change.
 2. List a short description of the update under that heading.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Only maintainers update the changelog during the merge process.
 
 ## Practical Examples & Templates (✅/❌)
+
 ### 2025-07-30
+
 ✅ Added detailed contribution instructions.
 
 ### 2025-01-15
+
 ✅ Initial repository creation.
 
 ## Known Issues & Friction Points
+
 - Keeping entries synchronized with commit history requires diligence.
 
 ## Tips & Best Practices
+
 - Keep descriptions short, ideally one line per change.
 
 ## Troubleshooting Guidance
+
 If a release entry appears missing, check the commit history and confirm whether
 the change was documented elsewhere.
 
 ## Dependencies, Risks & Escalation Path
+
 - Relies on maintainers accurately logging updates.
 - Escalate discrepancies via an issue.
 
 ## Success Metrics & Outcomes
+
 - Clear historical record of repository growth
 
 ## Resources & References
+
 - [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,92 @@
+---
+title: "CONTRIBUTING"
+archetype: "contributor-guide"
+status: "stable"
+owner: "Shailesh Rawat"
+maintainer: "Shailesh Rawat"
+version: "1.0"
+tags: ["contributing", "guidelines"]
+last_reviewed: "2025-08-02"
+---
 # CONTRIBUTING
 
 ## Overview
+
 This document explains how to submit issues and pull requests to improve the
 repository.
 
 ## Why It Matters
+
 Clear contribution guidelines help maintain code quality and streamline the
 review process.
 
 ## Audience, Scope & Personas
+
 - External contributors proposing new content
 - Maintainers reviewing and merging changes
 
 ## Prerequisites
+
 - Git and GitHub account
 - Familiarity with the project's README and relevant `AGENTS.md`
 
+> ℹ️ **Note:** This guide assumes you have Node.js and npm installed.
+
 ## Security, Compliance & Privacy
+
 Do not include sensitive data in issues or commits. Follow all security and
 privacy guidance defined in the root `AGENTS.md`.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Fork the repository and create a feature branch.
 2. Run `scripts/setup-environment.sh` to install markdownlint-cli2 and other tools.
 3. Make your changes while adhering to documentation standards.
-4. Run markdownlint if available and note any issues.
-5. Open a pull request describing your changes and referencing related issues.
+4. Run `npm run lint` to validate Markdown formatting.
+5. Run `npm test`; the current suite prints "No tests".
+6. Open a pull request describing your changes and referencing related issues.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Only maintainers may merge pull requests. Contributors need approval via the
 GitHub review process.
 
 ## Practical Examples & Templates (✅/❌)
+
 ✅ Pull request message: "Adds examples to `docs/how-to-navigate.md` and updates
 `LICENSE-CONTENT.md`."
 
 ❌ Pull request message: "misc updates" (vague)
 
 ## Known Issues & Friction Points
+
 - Missing or outdated local `AGENTS.md` guidelines can cause confusion.
 
 ## Tips & Best Practices
+
 - Keep pull requests focused on a single goal.
 - Reference related issues in the pull request description.
 
 ## Troubleshooting Guidance
+
 If tests fail or markdownlint cannot run, mention that in the pull request so a
 maintainer can advise next steps.
 
 ## Dependencies, Risks & Escalation Path
+
 - Dependence on GitHub Actions for CI checks
 - Escalate unaddressed reviews via direct mention of maintainers in comments
 
 ## Success Metrics & Outcomes
+
 - Well-documented contributions that merge cleanly
 
 ## Resources & References
+
 - [GitHub Contribution Guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
 
 ## Last Reviewed / Last Updated
-2025-07-30
+
+Date: 2025-08-02
+Maintainer: Shailesh Rawat (PoeticMayhem)
+Status: Stable – Version 1.0

--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,54 +1,69 @@
 # Content License
 
 ## Overview
+
 This repository's written content is provided under the Creative Commons
 Attribution 4.0 International (CC BY 4.0) license.
 
 ## Why It Matters
+
 The license clarifies how others may reuse, modify and distribute the
 documentation.
 
 ## Audience, Scope & Personas
+
 - Anyone interested in reusing or contributing documentation
 
 ## Prerequisites
+
 - Familiarity with basic open-source licensing principles
 
 ## Security, Compliance & Privacy
+
 No personal data is included in the license text. Follow privacy standards when
 submitting content.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Include attribution to the original author when reusing content.
 2. Indicate if you made any modifications.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 The license permits commercial and non-commercial use provided attribution is
 given.
 
 ## Practical Examples & Templates (✅/❌)
+
 ✅ "Content adapted from the Techno-Functional Portfolio under CC BY 4.0."
 
 ❌ "Content copied with no attribution."
 
 ## Known Issues & Friction Points
+
 - Some contributors may be unfamiliar with Creative Commons requirements.
 
 ## Tips & Best Practices
+
 - Provide a link to this file whenever you reuse material externally.
 
 ## Troubleshooting Guidance
+
 For questions on acceptable use, consult the repository maintainers.
 
 ## Dependencies, Risks & Escalation Path
+
 - Proper attribution is required to comply with the license.
 - Escalate disputes or violations through repository issues.
 
 ## Success Metrics & Outcomes
+
 - Clear reuse rights promote collaboration.
 
 ## Resources & References
+
 - [Creative Commons CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/LICENSE-MIT.md
+++ b/LICENSE-MIT.md
@@ -1,28 +1,34 @@
 # MIT License
 
 ## Overview
+
 This project uses the MIT License, a permissive open-source license that allows
 reuse with minimal restrictions.
 
 ## Why It Matters
+
 The license encourages wide adoption of the code while protecting contributors
 from liability.
 
 ## Audience, Scope & Personas
+
 - Developers and organizations reusing the source code
 
 ## Prerequisites
+
 - None
 
 ## Security, Compliance & Privacy
+
 The license does not grant rights to use trademarks or contributor names. No
 personal data is collected.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Include the following license text with any redistributed copies of the
    software.
 
-```
+```text
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -43,32 +49,41 @@ SOFTWARE.
 ```
 
 ## Access Control & Permissions (RBAC guidelines)
+
 The MIT License grants broad permissions as long as the license text is
 included with distributions.
 
 ## Practical Examples & Templates (✅/❌)
+
 ✅ Use portions of the code in another project while including this license.
 
 ❌ Redistribute code without including the license text.
 
 ## Known Issues & Friction Points
+
 - Misplacing or omitting the license text can create legal ambiguity.
 
 ## Tips & Best Practices
+
 - Keep this file intact whenever you fork or reuse the repository.
 
 ## Troubleshooting Guidance
+
 If you are unsure about permitted uses, consult legal counsel or open an issue
 for clarification.
 
 ## Dependencies, Risks & Escalation Path
+
 - Ensure derivative works respect the original license terms.
 
 ## Success Metrics & Outcomes
+
 - Code reuse without licensing disputes
 
 ## Resources & References
+
 - [Open Source Initiative MIT](https://opensource.org/licenses/MIT)
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,49 +1,64 @@
 # Assets
 
 ## Overview
+
 This directory stores project visuals, diagrams, and screenshots referenced throughout the documentation.
 
 ## Why It Matters
+
 Centralizing graphics ensures you can easily maintain and reference visual assets across documents.
 
 ## Audience, Scope & Personas
+
 All contributors using or adding images, diagrams, or screenshots to support documentation.
 
 ## Prerequisites
+
 - Ensure images contain no sensitive information.
 
 ## Security, Compliance & Privacy
+
 Follow global repository guidelines; avoid embedding confidential data in graphics.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Add new graphics in the appropriate subfolder: `diagrams`, `visuals`, or `screenshots`.
 2. Commit the assets with meaningful file names.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Only maintainers with write access may commit new images.
 
 ## Practical Examples & Templates (✅/❌)
+
 - ✅ `diagram-system-architecture.png`
 - ❌ `image1.png`
 
 ## Known Issues & Friction Points
+
 Large image files may increase repository size.
 
 ## Tips & Best Practices
+
 - Use descriptive file names in kebab-case.
 - Optimize images for size and clarity.
 
 ## Troubleshooting Guidance
+
 If assets do not render correctly, verify the file path in your markdown.
 
 ## Dependencies, Risks & Escalation Path
+
 Large assets might exceed repository limits; raise concerns to maintainers.
 
 ## Success Metrics & Outcomes
+
 Consistent, easily maintainable visuals across documentation.
 
 ## Resources & References
+
 Refer to `AGENTS.md` for content governance guidelines.
 
 ## Last Reviewed / Last Updated
+
 30 July 2025

--- a/assets/diagrams/README.md
+++ b/assets/diagrams/README.md
@@ -1,7 +1,9 @@
 # Diagrams
 
 ## Overview
+
 Store system and process diagrams here.
 
 ## Last Reviewed / Last Updated
+
 30 July 2025

--- a/assets/screenshots/README.md
+++ b/assets/screenshots/README.md
@@ -1,7 +1,9 @@
 # Screenshots
 
 ## Overview
+
 Store workflow screenshots here for reference in documentation.
 
 ## Last Reviewed / Last Updated
+
 30 July 2025

--- a/assets/visuals/README.md
+++ b/assets/visuals/README.md
@@ -1,7 +1,9 @@
 # Visuals
 
 ## Overview
+
 Store UI mockups or design assets here.
 
 ## Last Reviewed / Last Updated
+
 30 July 2025

--- a/ci-cd-logic/AGENTS.md
+++ b/ci-cd-logic/AGENTS.md
@@ -1,11 +1,12 @@
 # AGENTS.md – CI/CD Logic Standards
 
 ## 📌 Purpose
+
 - Provide reference patterns for GitHub Actions and automated documentation builds.
 - Follow the same CI/CD Automation Standards defined in `05-automation-ci-cd/AGENTS.md`.
 
 ## Key Points
+
 - Clearly document each workflow's purpose, triggers, and security controls.
 - Keep examples concise with shell or YAML snippets.
 - Review workflows quarterly or after significant pipeline changes.
-

--- a/ci-cd-logic/README.md
+++ b/ci-cd-logic/README.md
@@ -3,10 +3,10 @@
 This section contains workflow examples for building and deploying documentation.
 
 ## Key Files
+
 - `markdown-linting-pipeline.md` outlines lint checks.
 - `automated-publish-docs.md` explains how pages deploy.
 - `github-actions-patterns.md` lists reusable workflow snippets.
 
-Review each file for specific YAML configurations.
+Review each file for specific YAML configurations
 ---
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,54 +1,69 @@
 # Docs
 
 ## Overview
+
 This directory houses repository-wide references and navigation aids.
 
 ## Why It Matters
+
 Centralized docs help you quickly locate standards, workflows, and background context without searching each folder.
 
 ## Audience, Scope & Personas
+
 - New contributors needing orientation
 - Maintainers ensuring documentation stays consistent
 
 ## Prerequisites
+
 - Basic familiarity with GitHub and markdown
 
 ## Security, Compliance & Privacy
+
 Follow the security guidance in `/AGENTS.md`. Never store sensitive data here.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Review the Glossary for terminology.
 2. Read `how-to-navigate.md` to understand folder structure.
 3. Consult `overview-of-repo.md` for the big picture before contributing.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Everyone can read these docs. Only maintainers update or approve changes.
 
 ## Practical Examples & Templates (✅/❌)
+
 ✅ "Check `/docs/overview-of-repo.md` before submitting new content."
 
 ❌ "Just browse around until you find the right file."
 
 ## Known Issues & Friction Points
+
 Some topics still need expansion, so you may see brief sections awaiting more detail.
 
 ## Tips & Best Practices
+
 - Keep headings short and descriptive.
 - Cross-reference related docs to avoid duplication.
 
 ## Troubleshooting Guidance
+
 If you find outdated links or unclear instructions, open an issue so maintainers can address the problem.
 
 ## Dependencies, Risks & Escalation Path
+
 - Relies on contributors keeping this folder up to date.
 - Escalate persistent issues to repository maintainers listed in `CODEOWNERS`.
 
 ## Success Metrics & Outcomes
+
 - Faster onboarding for new team members
 - Consistent adherence to documentation standards
 
 ## Resources & References
+
 - [GitHub Docs](https://docs.github.com/en)
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/docs/glossary-of-terms.md
+++ b/docs/glossary-of-terms.md
@@ -1,35 +1,43 @@
 # Glossary of Terms
 
 ## Overview
+
 This file defines common vocabulary used across the portfolio to ensure
 consistent understanding between contributors.
 
 ## Why It Matters
+
 Clear terminology reduces miscommunication and accelerates onboarding for
 new team members.
 
 ## Audience, Scope & Personas
+
 - Contributors new to the repository
 - Cross‑functional stakeholders collaborating on projects
 
 ## Prerequisites
+
 - Basic familiarity with software development and content management
   concepts
 
 ## Security, Compliance & Privacy
+
 This glossary contains no sensitive data. It references security-related terms
 to promote awareness of best practices.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Locate the term you are unsure about.
 2. Review its definition and linked resources.
 3. If a key term is missing, open an issue to request an update.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 The glossary is read-only for most contributors. Only maintainers can approve
 new entries.
 
 ## Practical Examples & Templates (✅/❌)
+
 | Term | Definition |
 |------|------------|
 | CI/CD | Continuous Integration and Continuous Deployment |
@@ -43,28 +51,34 @@ new entries.
 ❌ Incorrect usage: "Update the CICD pipeline" (missing slash)
 
 ## Known Issues & Friction Points
+
 Some abbreviations have multiple interpretations across industries. Confirm the
 definition aligns with this repository before using a term in documentation.
 
 ## Tips & Best Practices
+
 - Keep definitions short and action oriented.
 - Provide links to external references when useful.
 
 ## Troubleshooting Guidance
+
 If a term seems unclear or has multiple meanings, raise a question in the issue
 tracker to clarify it before proceeding.
 
 ## Dependencies, Risks & Escalation Path
+
 - No direct dependencies.
 - Escalate unresolved terminology questions to the repository maintainers.
 
 ## Success Metrics & Outcomes
+
 - Shared vocabulary across documentation and projects
 
 ## Resources & References
+
 - [Wikipedia](https://en.wikipedia.org/wiki/Glossary)
 - [DevOps Glossary](https://www.atlassian.com/devops/devops-tools/devops-glossary)
 
 ## Last Reviewed / Last Updated
-2025-07-30
 
+2025-07-30

--- a/docs/how-to-navigate.md
+++ b/docs/how-to-navigate.md
@@ -1,25 +1,31 @@
 # How to Navigate
 
 ## Overview
+
 This guide explains how to locate key information and contribute efficiently
 within this repository.
 
 ## Why It Matters
+
 Following a consistent navigation approach helps all contributors find the right
 resources quickly and reduces ramp-up time.
 
 ## Audience, Scope & Personas
+
 - New contributors
 - Experienced maintainers who need a refresher
 
 ## Prerequisites
+
 - Familiarity with Git and GitHub basics
 
 ## Security, Compliance & Privacy
+
 Always review directory-specific `AGENTS.md` files for security and compliance
 guidelines before committing changes.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Start at the top-level `README.md` for a high-level overview of the
    repository structure.
 2. Navigate into each folder and read the local `README.md` to understand its
@@ -30,36 +36,44 @@ guidelines before committing changes.
    workflow explanations.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Most documentation is publicly readable. Merge permissions are limited to the
 maintainers specified in `CODEOWNERS`.
 
 ## Practical Examples & Templates (✅/❌)
+
 ✅ "Refer to `/05-automation-ci-cd/README.md` for CI/CD guidelines."
 
 ❌ "Just guess which folder holds the automation docs."
 
 ## Known Issues & Friction Points
+
 - Large directory trees can feel overwhelming at first glance.
 - Some files may have overlapping information.
 
 ## Tips & Best Practices
+
 - Use GitHub's search to locate files quickly.
 - Bookmark the `docs/` directory for reference material.
 
 ## Troubleshooting Guidance
+
 If a link in any README or documentation appears broken, open an issue so it can
 be corrected promptly.
 
 ## Dependencies, Risks & Escalation Path
+
 - Navigation relies on accurate README and `AGENTS.md` content.
 - Escalate persistent confusion to repository maintainers.
 
 ## Success Metrics & Outcomes
+
 - Contributors can locate information without assistance.
 
 ## Resources & References
+
 - [GitHub Documentation](https://docs.github.com/en)
 
 ## Last Reviewed / Last Updated
-2025-07-30
 
+2025-07-30

--- a/docs/overview-of-repo.md
+++ b/docs/overview-of-repo.md
@@ -1,59 +1,73 @@
 # Overview of Repo
 
 ## Overview
+
 This repository houses documentation, automation logic and workflow templates
 that demonstrate best practices across business analysis, communications and
 technical enablement.
 
 ## Why It Matters
+
 A consistent structure makes it easier for contributors to locate examples and
 extend the portfolio for their own needs.
 
 ## Audience, Scope & Personas
+
 - Content strategists looking for repeatable patterns
 - Developers and automation engineers
 - Stakeholders reviewing technical change initiatives
 
 ## Prerequisites
+
 - Familiarity with GitHub basics and markdown editing
 
 ## Security, Compliance & Privacy
+
 Ensure all contributions follow the security guidelines outlined in the root
 `AGENTS.md`. Do not include sensitive information in any commit.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Review the folder names for a thematic breakdown of assets.
 2. Open the relevant `README.md` to learn about the purpose of each folder.
 3. Follow `AGENTS.md` instructions before modifying or adding content.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 Write access is limited to maintainers listed in `CODEOWNERS`. External
 contributions require pull requests for review.
 
 ## Practical Examples & Templates (✅/❌)
+
 - ✅ Store automation scripts under `05-automation-ci-cd/`.
 - ❌ Mix unrelated personal files into project folders.
 
 ## Known Issues & Friction Points
+
 - Some areas still contain placeholder content awaiting expansion.
 
 ## Tips & Best Practices
+
 - Keep directory names short and descriptive.
 - Cross‑reference related documents to avoid duplication.
 
 ## Troubleshooting Guidance
+
 If you cannot find a file, use the repository search or consult the glossary.
 
 ## Dependencies, Risks & Escalation Path
+
 - None for general navigation
 - Escalate repository access issues to maintainers
 
 ## Success Metrics & Outcomes
+
 - Faster onboarding for new contributors
 
 ## Resources & References
+
 - Internal documentation style guides
 
 ## Last Reviewed / Last Updated
-2025-07-30
 
+2025-07-30

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "markdownlint-cli2 '**/*.md' '!node_modules'",
+    "test": "echo \"No tests\""
   },
   "repository": {
     "type": "git",

--- a/projects/data-analysis/README.md
+++ b/projects/data-analysis/README.md
@@ -9,12 +9,15 @@ last_reviewed: 2025-07-30
 # Data Analysis
 
 ## Overview
+
 This project provides a framework for data analysis tasks within the Sans Serif Sentiments organization. It outlines the approach, tools, and best practices for extracting insights from raw data. The goal is to help you move from scattered datasets to actionable recommendations in a repeatable, secure manner. Whether you work with marketing data, operational metrics, or customer feedback, this guide shows you how to plan your analysis, maintain data integrity, and share results effectively.
 
 ## Why It Matters
+
 Data-driven decisions lead to better outcomes. Without a consistent approach, you risk misinterpreting trends or missing key patterns. A well-defined framework ensures that analysis is both reliable and reproducible. This project explains how to structure your work so that other teams can understand and trust your findings. Proper data analysis drives improved customer engagement, identifies operational bottlenecks, and guides strategic investments.
 
 ## Audience, Scope & Personas
+
 This guide targets data analysts, business intelligence specialists, data engineers, and managers who rely on data-driven insights. Personas include:
 
 - **Marketing Analyst** – monitors campaign performance and recommends adjustments.
@@ -25,6 +28,7 @@ This guide targets data analysts, business intelligence specialists, data engine
 The scope covers everything from data ingestion to visualization. It assumes you have basic familiarity with spreadsheets or a scripting language like Python.
 
 ## Prerequisites
+
 Before you begin analyzing data, confirm the following prerequisites:
 
 1. **Access to Data Sources** – ensure you have permission to read the relevant databases or files.
@@ -36,6 +40,7 @@ Before you begin analyzing data, confirm the following prerequisites:
 Having these prerequisites in place prevents rework and ensures your findings align with organizational objectives.
 
 ## Security, Compliance & Privacy
+
 Data analysis must respect security and privacy rules to protect proprietary and personal information. Follow these guidelines:
 
 - **Role-Based Access Control** – limit data access to authorized team members. Use your organization's identity management system to assign appropriate roles.
@@ -47,6 +52,7 @@ Data analysis must respect security and privacy rules to protect proprietary and
 Maintaining security and compliance not only protects the organization but also ensures you can share results widely without violating policies.
 
 ## Tasks & Step-by-Step Instructions
+
 The following steps outline a repeatable workflow for data analysis:
 
 1. **Define the Question** – start with a clear objective. For example, "Which marketing channels drive the most engaged leads?"
@@ -61,6 +67,7 @@ The following steps outline a repeatable workflow for data analysis:
 Consistent execution of these steps ensures your analysis process remains transparent and repeatable.
 
 ## Access Control & Permissions
+
 You should separate duties and manage permissions carefully:
 
 - **Read Access** – analysts require read-only access to production data to prevent accidental modification.
@@ -71,6 +78,7 @@ You should separate duties and manage permissions carefully:
 Clear access controls reduce the risk of unauthorized data leaks or accidental changes to core systems.
 
 ## Practical Examples & Templates (✅/❌)
+
 Below are examples of effective versus ineffective practices:
 
 ✅ **Effective:**
@@ -88,6 +96,7 @@ Below are examples of effective versus ineffective practices:
 Using these templates ensures your audience quickly grasps the meaning behind your analysis.
 
 ## Known Issues & Friction Points
+
 During data analysis, you may run into common problems:
 
 - **Inconsistent Data Formats** – different systems may store dates, currencies, or units in various formats, causing parsing errors.
@@ -99,6 +108,7 @@ During data analysis, you may run into common problems:
 Acknowledging these issues early helps you set realistic timelines and plan mitigation steps.
 
 ## Tips & Best Practices
+
 Consider these best practices for efficient analysis:
 
 - **Start with a Hypothesis** – know what you expect to find. A hypothesis guides your exploration and prevents aimless data dredging.
@@ -110,6 +120,7 @@ Consider these best practices for efficient analysis:
 Adhering to these tips improves both the quality and efficiency of your analysis work.
 
 ## Troubleshooting Guidance
+
 If you encounter errors or inconsistent results, follow these troubleshooting steps:
 
 - **Check Data Inputs** – verify that your data files or database queries returned complete datasets. Missing rows often explain unexpected results.
@@ -121,6 +132,7 @@ If you encounter errors or inconsistent results, follow these troubleshooting st
 Consistent troubleshooting steps help you recover from setbacks and maintain credibility.
 
 ## Dependencies, Risks & Escalation Path
+
 Recognize dependencies and plan for potential risks:
 
 - **Data Source Availability** – some systems may not provide reliable exports or might undergo maintenance. Schedule analysis tasks around maintenance windows.
@@ -132,6 +144,7 @@ Recognize dependencies and plan for potential risks:
 Documenting these dependencies ensures your analysis stays on schedule and maintains compliance.
 
 ## Success Metrics & Outcomes
+
 Evaluate your data analysis efforts with these metrics:
 
 - **Time to Insight** – measure how long it takes from receiving raw data to delivering actionable recommendations.
@@ -143,6 +156,7 @@ Evaluate your data analysis efforts with these metrics:
 These metrics show whether your analysis program delivers real value to the organization.
 
 ## Resources & References
+
 Use these resources to expand your skills and streamline projects:
 
 - **Internal Training Modules** – look for company-provided courses on data tools and privacy standards.
@@ -154,4 +168,5 @@ Use these resources to expand your skills and streamline projects:
 Regularly consult these references to stay current on best practices and tool updates.
 
 ## Last Reviewed / Last Updated
+
 2025-07-30

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -15,7 +15,7 @@ if ! [ -f "node_modules/.bin/markdownlint-cli2" ]; then
   exit 1
 fi
 
-# Step 2: Run markdownlint using npx
+# Step 2: Run markdownlint using npx (respects patterns in .markdownlintignore)
 echo "✅ Running markdownlint-cli2 (local)..."
 npx markdownlint-cli2 "**/*.md" --config "$CONFIG_FILE"
 

--- a/style-guide/AGENTS.md
+++ b/style-guide/AGENTS.md
@@ -1,5 +1,5 @@
 
------
+---
 
 # Sans Serif Sentiments – Documentation Content & Style Guide
 
@@ -12,7 +12,7 @@ This guide establishes the definitive standards for writing, structuring, and go
 
 Adherence to this guide is non-negotiable and it supersedes any inherited or upstream standards.
 
------
+---
 
 ## 📌 1. Core Principles
 
@@ -26,7 +26,7 @@ Our documentation is a product. It must be designed and engineered with the same
 | **Consistency Builds Trust** | A consistent structure, tone, and format across all documents creates a predictable and trustworthy user experience. |
 | **Context Over Content** | Do not just explain *what* to do; explain *why* it's important. Frame technical instructions with strategic purpose and rationale. |
 
------
+---
 
 ## 🧱 2. Content Archetypes (Diátaxis-Aligned)
 
@@ -43,35 +43,35 @@ Every piece of documentation must map to **exactly one** of the four Diátaxis a
 
 A tutorial is a lesson. It guides a newcomer through a series of steps to complete a meaningful project.
 
-  * **Structure:** Linear, numbered steps. Start with prerequisites and end with a tangible result.
-  * **Do:** Promise a specific outcome (e.g., "By the end of this tutorial, you will have a deployed application").
-  * **Do not:** Explain concepts in-depth. Link to *Explanation* documents instead.
+- **Structure:** Linear, numbered steps. Start with prerequisites and end with a tangible result.
+- **Do:** Promise a specific outcome (e.g., "By the end of this tutorial, you will have a deployed application").
+- **Do not:** Explain concepts in-depth. Link to *Explanation* documents instead.
 
 ### ✅ How-To Guide
 
 A how-to guide is a recipe to solve a specific problem. It assumes the user has some background knowledge.
 
-  * **Structure:** Numbered or bulleted list of instructions.
-  * **Do:** Focus on one discrete task.
-  * **Do not:** Include conceptual background or multiple unrelated tasks.
+- **Structure:** Numbered or bulleted list of instructions.
+- **Do:** Focus on one discrete task.
+- **Do not:** Include conceptual background or multiple unrelated tasks.
 
 ### ✅ Reference
 
 Reference material is technical description. It is encyclopedic and objective.
 
-  * **Structure:** Tables, parameter lists, API schemas, command flag definitions.
-  * **Tone:** Dry, factual, and information-dense.
-  * **Do not:** Include opinions, advice, or instructions.
+- **Structure:** Tables, parameter lists, API schemas, command flag definitions.
+- **Tone:** Dry, factual, and information-dense.
+- **Do not:** Include opinions, advice, or instructions.
 
 ### ✅ Explanation
 
 An explanation provides background and context. It builds understanding.
 
-  * **Structure:** Primarily prose, often supported by diagrams or historical context.
-  * **Do:** Discuss trade-offs, design decisions, and high-level architecture.
-  * **Do not:** Include step-by-step instructions.
+- **Structure:** Primarily prose, often supported by diagrams or historical context.
+- **Do:** Discuss trade-offs, design decisions, and high-level architecture.
+- **Do not:** Include step-by-step instructions.
 
------
+---
 
 ## ✍️ 3. Voice, Tone, and Mechanics
 
@@ -86,49 +86,49 @@ An explanation provides background and context. It builds understanding.
 | **Sentence Structure** | Write short, simple sentences. One idea per sentence. | "Clone the repository. Then, install the dependencies." | "After you clone the repository, the dependencies must be installed." |
 | **Serial Comma** | Use the Oxford (serial) comma in lists of three or more items. | "Configure the client, server, and database." | "Configure the client, server and database." |
 
------
+---
 
 ## 🧾 4. Formatting and Structure
 
 ### File & Folder Naming
 
-  * Use **lowercase kebab-case** for all file and folder names.
-      * ✅ `api-reference.md`
-      * ✅ `how-to-configure-tls/`
-      * ❌ `APIReference.md`, `ConfigureTLS.md`
+- Use **lowercase kebab-case** for all file and folder names.
+  - ✅ `api-reference.md`
+  - ✅ `how-to-configure-tls/`
+  - ❌ `APIReference.md`, `ConfigureTLS.md`
 
 ### Headings
 
-  * Use a single `#` (H1) for the document title, derived from the `title` frontmatter.
-  * Use `##` (H2) for major sections, and `###` (H3) for sub-sections. Avoid going deeper than `####` (H4).
-  * Use sentence case for all headings.
-      * ✅ `## Configure the production environment`
-      * ❌ `## Configure The Production Environment` or `## CONFIGURE...`
+- Use a single `#` (H1) for the document title, derived from the `title` frontmatter.
+- Use `##` (H2) for major sections, and `###` (H3) for sub-sections. Avoid going deeper than `####` (H4).
+- Use sentence case for all headings.
+  - ✅ `## Configure the production environment`
+  - ❌ `## Configure The Production Environment` or `## CONFIGURE...`
 
 ### Links
 
-  * Use descriptive text that makes sense out of context.
-      * ✅ `For more details, see the [deployment checklist](./deployment-checklist.md).`
-      * ❌ `For more details, [click here](./checklist.md).`
+- Use descriptive text that makes sense out of context.
+  - ✅ `For more details, see the [deployment checklist](./deployment-checklist.md).`
+  - ❌ `For more details, [click here](./checklist.md).`
 
 ### Lists
 
-  * Use `-` for unordered lists.
-  * Use `1.` for ordered lists where sequence is critical (e.g., steps in a How-To Guide).
+- Use `-` for unordered lists.
+- Use `1.` for ordered lists where sequence is critical (e.g., steps in a How-To Guide).
 
 ### Emphasis
 
-  * Use **bold** (`**text**`) for UI elements, or to add strong emphasis.
-  * Use *italics* (`*text*`) for conceptual terms on first use.
-  * Use `backticks` for inline code, commands, variables, file paths, and keys.
-      * ✅ Set the `API_KEY` in your `.env` file.
-      * ❌ Do not use backticks for emphasis or to quote text.
+- Use **bold** (`**text**`) for UI elements, or to add strong emphasis.
+- Use *italics* (`*text*`) for conceptual terms on first use.
+- Use `backticks` for inline code, commands, variables, file paths, and keys.
+  - ✅ Set the `API_KEY` in your `.env` file.
+  - ❌ Do not use backticks for emphasis or to quote text.
 
 ### Code Blocks
 
-  * Always specify the language for syntax highlighting.
+- Always specify the language for syntax highlighting.
 
-  * Do not prefix shell commands with `$` or `>` unless demonstrating a complete terminal session with user input and machine output.
+- Do not prefix shell commands with `$` or `>` unless demonstrating a complete terminal session with user input and machine output.
 
     ```bash
     # Install dependencies
@@ -138,9 +138,10 @@ An explanation provides background and context. It builds understanding.
     npm run dev
     ```
 
------
+---
 
-### Enhance your markdown output to follow the following UX rules:
+### Enhance your markdown output to follow the following UX rules
+
 - Use markdown tables wherever roles, outcomes, or comparisons exist
 - Include ✅/❌ do/don’t lists where applicable
 - Use code blocks for all reusable templates or formatting examples
@@ -152,25 +153,27 @@ An explanation provides background and context. It builds understanding.
 
 ### Screenshots
 
-  * **Currency:** Screenshots must be current and reflect the latest UI.
-  * **Annotation:** Use simple boxes or arrows to highlight specific elements.
-  * **Redaction:** Censor or remove any personal user data, secrets, or internal hostnames.
-  * **Alt Text:** All images require descriptive alt text. `✅ ![Diagram of the authentication token flow.](./auth-flow.png)`
+- **Currency:** Screenshots must be current and reflect the latest UI.
+- **Annotation:** Use simple boxes or arrows to highlight specific elements.
+- **Redaction:** Censor or remove any personal user data, secrets, or internal hostnames.
+- **Alt Text:** All images require descriptive alt text. `✅ ![Diagram of the authentication token flow.](./auth-flow.png)`
 
 ### Diagrams
 
-  * **Prefer Code-Based Diagrams:** Whenever possible, use Mermaid.js for diagrams. This allows them to be version-controlled and updated easily.
-    ````
-    ```mermaid
+- **Prefer Code-Based Diagrams:** Whenever possible, use Mermaid.js for diagrams. This allows them to be version-controlled and updated easily.
+
+    ````text
+    ```
     graph TD;
         A[Client] -->|Request| B(API Gateway);
         B --> C{Authentication};
         C -->|Valid| D[Service];
+    ```text
     ```
-    ````
-  * **Clarity:** Ensure diagrams are simple, legible, and directly support the accompanying text. Describe complex diagrams in an adjacent paragraph.
 
------
+- **Clarity:** Ensure diagrams are simple, legible, and directly support the accompanying text. Describe complex diagrams in an adjacent paragraph.
+
+---
 
 ## 📢 6. Callouts
 
@@ -184,25 +187,25 @@ Use blockquotes with a leading emoji to draw attention to critical information.
 
 > 🛑 **Warning** \> Alerts the user to a high-risk action that could result in data loss, system failure, security vulnerabilities, or other irreversible outcomes.
 
------
+---
 
 ## ♿ 7. Accessibility (a11y)
 
-  * **Alt Text:** All images must have meaningful alt text describing their content and purpose.
-  * **Link Text:** Link text must be descriptive and make sense without surrounding context (See [Links](https://www.google.com/search?q=%23links)).
-  * **Tables:** Tables must have headers (`| Header 1 | Header 2 |`). Do not use images of tables.
-  * **Directional Language:** Avoid phrases like "as you can see above" or "in the section below." Use descriptive links to refer to other sections.
+- **Alt Text:** All images must have meaningful alt text describing their content and purpose.
+- **Link Text:** Link text must be descriptive and make sense without surrounding context (See [Links](https://www.google.com/search?q=%23links)).
+- **Tables:** Tables must have headers (`| Header 1 | Header 2 |`). Do not use images of tables.
+- **Directional Language:** Avoid phrases like "as you can see above" or "in the section below." Use descriptive links to refer to other sections.
 
------
+---
 
 ## 🔐 8. Security & Compliance
 
-  * **No Secrets:** Never commit secrets, credentials, passwords, or active API tokens to the repository, even in documentation.
-  * **Use Placeholders:** Use clear placeholders like `YOUR_API_KEY_HERE` or `_REDACTED_`.
-  * **Destructive Actions:** Any command or procedure that is destructive (e.g., `rm -rf`, deleting a database) or irreversible *must* be preceded by a `🛑 Warning` callout.
-  * **Access Control:** When documenting features related to permissions, clearly state the required roles or access levels (e.g., "This action requires `Admin` role.").
+- **No Secrets:** Never commit secrets, credentials, passwords, or active API tokens to the repository, even in documentation.
+- **Use Placeholders:** Use clear placeholders like `YOUR_API_KEY_HERE` or `_REDACTED_`.
+- **Destructive Actions:** Any command or procedure that is destructive (e.g., `rm -rf`, deleting a database) or irreversible *must* be preceded by a `🛑 Warning` callout.
+- **Access Control:** When documenting features related to permissions, clearly state the required roles or access levels (e.g., "This action requires `Admin` role.").
 
------
+---
 
 ## 🗃️ 9. Document Lifecycle & Governance
 
@@ -222,40 +225,40 @@ last_reviewed: 2025-07-30
 ---
 ```
 
-  * **`owner`**: The individual or team (`@org/team-name`) responsible for the document's accuracy.
-  * **`status`**: The current state of the document.
-      * `draft`: Work in progress, not yet published or reliable.
-      * `current`: Verified, accurate, and up-to-date.
-      * `needs-review`: Outdated or requires verification.
-      * `deprecated`: No longer recommended. A newer alternative exists.
-      * `archived`: Obsolete and retained only for historical purposes.
-  * **`last_reviewed`**: The date (`YYYY-MM-DD`) the content was last verified for accuracy.
+- **`owner`**: The individual or team (`@org/team-name`) responsible for the document's accuracy.
+- **`status`**: The current state of the document.
+  - `draft`: Work in progress, not yet published or reliable.
+  - `current`: Verified, accurate, and up-to-date.
+  - `needs-review`: Outdated or requires verification.
+  - `deprecated`: No longer recommended. A newer alternative exists.
+  - `archived`: Obsolete and retained only for historical purposes.
+- **`last_reviewed`**: The date (`YYYY-MM-DD`) the content was last verified for accuracy.
 
 ### Review Cadence
 
-  * The `owner` is responsible for reviewing their documents at least **every 6 months**.
-  * After a review, the `last_reviewed` date must be updated, even if no content changes were made.
+- The `owner` is responsible for reviewing their documents at least **every 6 months**.
+- After a review, the `last_reviewed` date must be updated, even if no content changes were made.
 
 ### Deprecation & Deletion
 
-  * **Do not delete documents.** Deleting files breaks existing URLs and bookmarks.
-  * To deprecate a document:
-    1.  Change the `status` in the frontmatter to `deprecated`.
-    2.  Add a `📝 Note` or `⚠️ Caution` callout at the top of the file explaining that the document is outdated and linking to the recommended replacement.
-    3.  Eventually, the status can be changed to `archived` and the content can be replaced with a single link to the new resource.
+- **Do not delete documents.** Deleting files breaks existing URLs and bookmarks.
+- To deprecate a document:
+    1. Change the `status` in the frontmatter to `deprecated`.
+    2. Add a `📝 Note` or `⚠️ Caution` callout at the top of the file explaining that the document is outdated and linking to the recommended replacement.
+    3. Eventually, the status can be changed to `archived` and the content can be replaced with a single link to the new resource.
 
------
+---
 
 ## 🤖 10. Linting, Validation & CI
 
 Our CI/CD pipeline automates quality control for all documentation. Pull requests will be blocked if these checks fail.
 
-  * **Linting:** All Markdown files must pass validation against our shared `.markdownlint.json` configuration.
-  * **Frontmatter Validation:** The CI will verify that all required frontmatter fields (`title`, `archetype`, `owner`, `status`, `last_reviewed`) are present and correctly formatted.
-  * **Script Validation:** All shell scripts (`.sh`) included in documentation examples or repositories must pass `shellcheck`.
-  * **Link Checking:** The CI will perform checks for broken internal and external links.
+- **Linting:** All Markdown files must pass validation against our shared `.markdownlint.json` configuration.
+- **Frontmatter Validation:** The CI will verify that all required frontmatter fields (`title`, `archetype`, `owner`, `status`, `last_reviewed`) are present and correctly formatted.
+- **Script Validation:** All shell scripts (`.sh`) included in documentation examples or repositories must pass `shellcheck`.
+- **Link Checking:** The CI will perform checks for broken internal and external links.
 
------
+---
 
 ## 📚 11. Authoritative References
 

--- a/style-guide/README.md
+++ b/style-guide/README.md
@@ -3,42 +3,38 @@
 
 # Style Guide
 
-
 **Version 1.0 • 2025-05-19**
 
 _A living framework for calm, clear, human-first documentation._
 
-***
+---
 
 ## 1. Purpose of This Guide
-
 
 > A style guide is not just about formatting—it's about trust.\
 > This document exists to create a **shared voice**, a **clear standard**, and a **reliable starting point** for anyone contributing to sans-serif-sentiments.
 
 You can use this guide when:
 
-* You're writing docs, READMEs, guides, or changelogs
-* You're reviewing someone else’s writing
-* You’re rewriting dry tech speak into something more human
+- You're writing docs, READMEs, guides, or changelogs
+- You're reviewing someone else’s writing
+- You’re rewriting dry tech speak into something more human
 
 This isn’t about rules. It’s about rhythm.
 
-***
+---
 
 ## 2. Tone & Voice
-
 
 _Calm, clear, sincere—never robotic._
 
 Your writing should feel like a conversation with someone who’s:
 
-* Confident but not arrogant
-* Knowledgeable but not preachy
-* Friendly but not trying too hard
+- Confident but not arrogant
+- Knowledgeable but not preachy
+- Friendly but not trying too hard
 
-###  What We Aim For
-
+### What We Aim For
 
 | Trait       | What It Means                                                            |
 | ----------- | ------------------------------------------------------------------------ |
@@ -48,10 +44,9 @@ Your writing should feel like a conversation with someone who’s:
 | **Minimal** | Don’t write a sentence when a phrase will do. Let whitespace speak.      |
 | **Human**   | We talk like real people. Write like someone who wants to be understood. |
 
-***
+---
 
 ### ❌ Cold, Robotic
-
 
 ```markdown
 To proceed with installation, users are advised to verify system prerequisites prior to continuing.
@@ -59,16 +54,14 @@ To proceed with installation, users are advised to verify system prerequisites p
 
 ### ✅ Calm + Human
 
-
 ```markdown
 Before you install, check if your system meets the requirements.
 It takes 30 seconds and saves frustration later.
 ```
 
-***
+---
 
 ### ❌ Corporate & Vague
-
 
 ```markdown
 Our platform leverages AI capabilities to enhance synergies across verticals.
@@ -76,15 +69,13 @@ Our platform leverages AI capabilities to enhance synergies across verticals.
 
 ### ✅ Sincere + Clear
 
-
 ```markdown
 We use AI to help teams work faster and with fewer manual tasks.
 ```
 
-***
+---
 
 ### ❌ Friendly but Overdone
-
 
 ```markdown
 Hey there, champ! 😎 Ready to install some software?! Let’s crush it! 💥
@@ -92,29 +83,26 @@ Hey there, champ! 😎 Ready to install some software?! Let’s crush it! 💥
 
 ### ✅ Friendly and Respectful
 
-
 ```markdown
 Let’s get you set up. This guide takes about 3 minutes to follow.
 ```
 
-***
+---
 
 > Write like you're helping someone intelligent—but tired.\
 > That’s the reader who matters most.
 
-***
+---
 
 ## 3. Structure & Hierarchy
-
 
 _When and how to use headings and whitespace._
 
 Your doc should feel like a conversation with chapters—not a cluttered note.
 
-***
+---
 
-###  Use heading levels to guide the eye:
-
+### Use heading levels to guide the eye
 
 | Markdown  | Purpose                                  |
 | --------- | ---------------------------------------- |
@@ -126,10 +114,9 @@ Your doc should feel like a conversation with chapters—not a cluttered note.
 ✅ Use **1 blank line** before and after headings.\
 ✅ Start each section with a quick sentence or blockquote for orientation.
 
-***
+---
 
 ### ❌ Cluttered Heading Use
-
 
 ```markdown
 # How it Works
@@ -147,7 +134,6 @@ Your doc should feel like a conversation with chapters—not a cluttered note.
 ```
 
 ### ✅ Clear Hierarchy
-
 
 ```markdown
 # How It Works
@@ -169,43 +155,42 @@ Describe what users should expect.
 Quick intro before listing features.
 ```
 
-***
+---
 
-###   Numbering Style Guidelines
+### Numbering Style Guidelines
 
-
-* ✅ Use numbers in the TOC for scanning and structure
-* ❌ Do not include numbering in actual document headings (`##`).
+- ✅ Use numbers in the TOC for scanning and structure
+- ❌ Do not include numbering in actual document headings (`##`).
 
 > This keeps URLs clean, anchors intuitive, and editing easier.
 
 > **When numbering can help:**
 >
-> * In a tutorial or linear flow where readers need to track “Step 1, Step 2…”
-> * When you’ll reference sections by number in discussion or reviews.
+> - In a tutorial or linear flow where readers need to track “Step 1, Step 2…”
+> - When you’ll reference sections by number in discussion or reviews.
 >
 > **Pros of numbering headings:**
 >
-> * Clarifies sequence and progress
-> * Makes it easy to say “see section 3”
+> - Clarifies sequence and progress
+> - Makes it easy to say “see section 3”
 >
 > **Cons of numbering headings:**
 >
-> * Pollutes anchor links and permalinks
-> * Requires renumbering whenever you insert or reorder sections
-> * Can distract in long or non-linear docs
+> - Pollutes anchor links and permalinks
+> - Requires renumbering whenever you insert or reorder sections
+> - Can distract in long or non-linear docs
 >
 > **Hybrid model:**\
 > Use numbers in the TOC only for order, but keep your `##` headings unnumbered for clean URLs and easier maintenance.
 
-***
+---
 
-###   Leading Sentences Guidelines
+### Leading Sentences Guidelines
 
+- ✅ Always start a new section or procedural list with a brief intro sentence that explains **why** the reader is here.
+- ❌ Avoid jumping straight into steps without context.
 
-* ✅ Always start a new section or procedural list with a brief intro sentence that explains **why** the reader is here.
-* ❌ Avoid jumping straight into steps without context.
-* #### 📌 📝 (More Examples)
+- #### 📌 📝 (More Examples)
 
 | ❌ Don’t Do This                                                            | ✅ Do This Instead                                                                                                                               |
 | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -216,14 +201,14 @@ Quick intro before listing features.
 
 > A quick orienting or opening line sets expectations and reduces confusion.
 
-***
+---
 
-###   Heading Consistency & Parallelism
+### Heading Consistency & Parallelism
 
+- ✅ Write related headings in the same grammatical form (e.g., all imperatives: “Install,” “Configure,” “Verify”).
+- ❌ Don’t mix styles like “Installing the Tool” with “Setup Instructions.”
 
-* ✅ Write related headings in the same grammatical form (e.g., all imperatives: “Install,” “Configure,” “Verify”).
-* ❌ Don’t mix styles like “Installing the Tool” with “Setup Instructions.”
-* #### 📌 🔗 (More Examples)
+- #### 📌 🔗 (More Examples)
 
 | ❌ Mixed Styles                                                                          | ✅ Parallel Imperatives                                                           |
 | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -234,10 +219,9 @@ Quick intro before listing features.
 
 > Parallel structure helps readers scan and know exactly what to expect.
 
-***
+---
 
-###  Good vs Bad Examples Summary Table
-
+### Good vs Bad Examples Summary Table
 
 | ❌ Don’t Do This                                      | ✅ Do This Instead                                                     |
 | ---------------------------------------------------- | --------------------------------------------------------------------- |
@@ -248,24 +232,21 @@ Quick intro before listing features.
 | Skip spacing between sections                        | Add whitespace before/after headings and between paragraphs           |
 | Include all concepts in one bloated section          | Split into logical sub-headings to improve scanning                   |
 
-***
+---
 
-##  Whitespace = Breathing Room
-
+## Whitespace = Breathing Room
 
 Use whitespace like punctuation. It slows the scroll and helps the eye.
 
-***
+---
 
 ### ❌ Wall of Text
-
 
 ```markdown
 To install the CLI tool, go to the website and download the installer. After that, run the installer and follow the setup wizard. Finally, verify the installation by typing `tool --version` in the terminal.
 ```
 
 ### ✅ Structured & Skimmable
-
 
 ````markdown
 ### Install the CLI Tool
@@ -276,11 +257,11 @@ To install the CLI tool, go to the website and download the installer. After tha
 3. Follow the setup wizard
 
 ✅ To confirm it worked:
-```bash
+```
 tool --version
-````
+````text
 
-````
+```
 
 ---
 
@@ -319,20 +300,18 @@ Use `**bold**` and `*italic*` intentionally. Don’t shout. Don’t decorate.
 
 ```markdown
 **IMPORTANT**: You MUST click the **FINAL** button at the **END** of the page.
-````
+```
 
 ### ✅ Balanced and Focused
-
 
 ```markdown
 Click the **Final** button at the end of the page.
 This step completes the setup.
 ```
 
-***
+---
 
 ### ❌ Emphasizing full sentences
-
 
 ```markdown
 **You should always check the version before upgrading.**
@@ -340,22 +319,19 @@ This step completes the setup.
 
 ### ✅ Use emphasis _within_ the sentence
 
-
 ```markdown
 You should always check the **version** before upgrading.
 ```
 
 > ✅ Let emphasis **support meaning**—not add noise.
 
-***
+---
 
 ## 5. Language & Word Choice
 
-
 _Preferred words, banned jargon._
 
-### ✅ Use simple, common words:
-
+### ✅ Use simple, common words
 
 | Bad                  | Better                  |
 | -------------------- | ----------------------- |
@@ -366,17 +342,15 @@ _Preferred words, banned jargon._
 | Interface (as noun)  | Screen, page, dashboard |
 | In order to          | To                      |
 
-### ❌ Avoid these patterns:
+### ❌ Avoid these patterns
 
+- "It is recommended that…" → say “We recommend…”
+- “At your earliest convenience…” → say “When you’re ready”
+- “Endeavor to…” → just… don’t.
 
-* "It is recommended that…" → say “We recommend…”
-* “At your earliest convenience…” → say “When you’re ready”
-* “Endeavor to…” → just… don’t.
-
-***
+---
 
 ### ❌ Vague, bloated
-
 
 ```markdown
 Our solution facilitates synergistic workflows across multiple platforms.
@@ -384,15 +358,13 @@ Our solution facilitates synergistic workflows across multiple platforms.
 
 ### ✅ Specific, human
 
-
 ```markdown
 Our tool helps teams work together across different apps—without switching tabs.
 ```
 
-***
+---
 
 ### ❌ Legalese-style
-
 
 ```markdown
 Users are advised to initiate credential verification upon initial login.
@@ -400,24 +372,21 @@ Users are advised to initiate credential verification upon initial login.
 
 ### ✅ Human-first
 
-
 ```markdown
 When you log in for the first time, we’ll ask you to verify your account.
 ```
 
 > Write like you're helping a smart friend, not submitting to a legal department.
 
-***
+---
 
 ## 6. Layout Patterns
-
 
 _Common structures for different doc types._
 
 Use these reusable layouts to speed up writing and bring consistency across docs.
 
-###  Setup Guide
-
+### Setup Guide
 
 ```markdown
 ## Getting Started
@@ -438,10 +407,9 @@ Break it into 2–3 bullets if needed.
 Show how success looks.
 ```
 
-***
+---
 
-###  How-To Guide
-
+### How-To Guide
 
 ```markdown
 ## How to Do One Specific Thing
@@ -456,10 +424,9 @@ Show how success looks.
 ✅ Result: What the user should see or achieve.
 ```
 
-***
+---
 
-###  Concept/Overview Doc
-
+### Concept/Overview Doc
 
 ```markdown
 ## What is [Concept]?
@@ -474,10 +441,9 @@ Show how success looks.
 
 > ✨ These aren’t strict templates. Think of them as scaffolding—there to support you, not box you in.
 
-***
+---
 
 ## 7. Content Philosophy
-
 
 _Empathy-led, human-first writing._
 
@@ -486,18 +452,16 @@ We write so the reader doesn’t have to feel stupid.
 
 This guide exists to protect that principle.
 
-***
+---
 
-###  Why This Philosophy Matters
-
+### Why This Philosophy Matters
 
 Documentation is the _first real conversation_ between your product and your user.\
 If that conversation is cold, robotic, or overloaded—they walk away.
 
-***
+---
 
-###  What We Believe
-
+### What We Believe
 
 | Principle                             | What It Means                                                        |
 | ------------------------------------- | -------------------------------------------------------------------- |
@@ -507,17 +471,15 @@ If that conversation is cold, robotic, or overloaded—they walk away.
 | **Anticipation builds trust**         | Predict what might confuse the reader—and address it before they ask |
 | **Tone is UX**                        | A friendly line at the right time does more than a button ever can   |
 
-***
+---
 
 ### ❌ A Typical, Surface-Level Doc
-
 
 ```markdown
 The installation process requires you to download the binary, extract it, and modify your PATH variable accordingly.
 ```
 
 ### ✅ A Human-First Rewrite
-
 
 ```markdown
 To install the tool:
@@ -531,10 +493,9 @@ Not sure what "PATH" means? No worries—[we’ll explain it here](#what-is-path
 
 > 🤝 Help before it’s asked for. Confidence before confusion.
 
-***
+---
 
 ### ❌ Corporate Legalese
-
 
 ```markdown
 This integration utilizes proprietary methods to ensure optimal connectivity across environments.
@@ -542,38 +503,34 @@ This integration utilizes proprietary methods to ensure optimal connectivity acr
 
 ### ✅ Sans-Serif Sentiments Style
 
-
 ```markdown
 We built this integration to be reliable, fast, and easy to connect—no matter your environment.
 ```
 
 > Say it like you’d say it in real life. Not like you’re talking to a boardroom.
 
-***
+---
 
 ## ✅ TL;DR
 
-
-* People don’t read docs because they _want_ to. They read them because they’re stuck.
-* We don’t waste their time trying to sound impressive—we respect it by being helpful.
-* Empathy isn’t a “nice-to-have”—it’s our UX strategy in writing.
+- People don’t read docs because they _want_ to. They read them because they’re stuck.
+- We don’t waste their time trying to sound impressive—we respect it by being helpful.
+- Empathy isn’t a “nice-to-have”—it’s our UX strategy in writing.
 
 > Clarity is the kindest thing we can offer someone mid-problem.
 
-***
+---
 
 ## 8. Markdown & Commit Style
-
 
 _The backbone of formatting clarity._
 
 Markdown is the shared language of your documentation.\
 Used well, it brings structure and calm. Used carelessly, it creates chaos.
 
-***
+---
 
 ### ✅ Markdown Guidelines
-
 
 | Task        | Rule                                        |
 | ----------- | ------------------------------------------- |
@@ -586,10 +543,9 @@ Used well, it brings structure and calm. Used carelessly, it creates chaos.
 ✅ Always use **one blank line** between headings, paragraphs, and list items.\
 ✅ Use indentation sparingly; avoid nested chaos.
 
-***
+---
 
 ### ❗ Common Markdown Mistakes to Avoid
-
 
 | Mistake                      | Better Approach                                              |
 | ---------------------------- | ------------------------------------------------------------ |
@@ -598,10 +554,9 @@ Used well, it brings structure and calm. Used carelessly, it creates chaos.
 | No blank lines around blocks | Markdown breaks—add spacing                                  |
 | Code without context         | Always add a sentence before code to explain what it does    |
 
-***
+---
 
-###  When to Use Inline vs Block Code
-
+### When to Use Inline vs Block Code
 
 | Use Case                                | Use This                                   |
 | --------------------------------------- | ------------------------------------------ |
@@ -611,10 +566,9 @@ Used well, it brings structure and calm. Used carelessly, it creates chaos.
 ✅ Be kind to the reader:\
 Use inline when referencing, block when teaching.
 
-***
+---
 
 ### ✅ Commit Message Style
-
 
 We use **conventional commit prefixes** for clarity and changelog generation:
 
@@ -630,24 +584,22 @@ chore: update dependencies
 ✅ Keep subject lines under 72 characters\
 ✅ Use lowercase prefixes (no `Feat:` or `Fix:`)
 
-***
+---
 
-###  Why It Matters
-
+### Why It Matters
 
 Your commit history is not just a log—it’s a **narrative**.\
 Clear messages help:
 
-* Auto-generate changelogs
-* Scan history during debugging
-* Guide code reviewers faster
+- Auto-generate changelogs
+- Scan history during debugging
+- Guide code reviewers faster
 
 > A good commit is a small act of documentation.
 
-***
+---
 
 ## 9. Accessibility & Inclusivity
-
 
 _Alt-text, plain language, and respect for real-world readers._
 
@@ -656,15 +608,14 @@ It’s about making your docs usable by people who are tired, rushed, anxious, d
 
 That includes:
 
-* Screen reader users
-* Non-native English speakers
-* Colorblind users
-* Newcomers who don’t know your product (yet)
+- Screen reader users
+- Non-native English speakers
+- Colorblind users
+- Newcomers who don’t know your product (yet)
 
-***
+---
 
-###  Core Principles
-
+### Core Principles
 
 | Principle                               | What It Means                                       |
 | --------------------------------------- | --------------------------------------------------- |
@@ -674,10 +625,9 @@ That includes:
 | **Link labels should describe action**  | Never say "click here"                              |
 | **Tone should respect all backgrounds** | No idioms, jokes, or references that might alienate |
 
-***
+---
 
 ### ❌ Inaccessible Example
-
 
 ```markdown
 Hey! Click here to learn more! 🎉
@@ -687,7 +637,6 @@ Hey! Click here to learn more! 🎉
 
 ### ✅ Inclusive Rewrite
 
-
 ```markdown
 Want a deeper explanation? [Read the API example guide](../examples/remapped-api.md)
 
@@ -696,32 +645,29 @@ Want a deeper explanation? [Read the API example guide](../examples/remapped-api
 
 ✅ The alt text explains what the graph _means_, not just what it _is_.
 
-***
+---
 
-###  Tools That Help
+### Tools That Help
 
+- [Hemingway Editor](https://hemingwayapp.com/) – Simplify complex sentences
+- [WAVE Accessibility Tool](https://wave.webaim.org/) – Audit contrast, alt text, etc.
+- [Inclusive Language Checker](https://alexjs.com/) – Detect biased or outdated terms
 
-* [Hemingway Editor](https://hemingwayapp.com/) – Simplify complex sentences
-* [WAVE Accessibility Tool](https://wave.webaim.org/) – Audit contrast, alt text, etc.
-* [Inclusive Language Checker](https://alexjs.com/) – Detect biased or outdated terms
+---
 
-***
+### TL;DR
 
-###  TL;DR
-
-
-* Add alt text that makes sense out of context
-* Write like your reader has one eye on the clock and one hand on their toddler
-* Don’t assume knowledge—or perfect English
-* Never use “click here” as link text
-* Keep sentence structure light, clean, and logically ordered
+- Add alt text that makes sense out of context
+- Write like your reader has one eye on the clock and one hand on their toddler
+- Don’t assume knowledge—or perfect English
+- Never use “click here” as link text
+- Keep sentence structure light, clean, and logically ordered
 
 > Accessibility isn’t extra effort. It’s built-in empathy.
 
-***
+---
 
 ## 10. Localization & Translation
-
 
 _Placeholder syntax, tone shifts, and global awareness._
 
@@ -730,10 +676,9 @@ Good docs speak many languages—even when they’re only written in one.
 Localization doesn’t start with translation.\
 It starts with writing that’s clear, culture-neutral, and easy to adapt.
 
-***
+---
 
-###  Key Practices for Localization-Friendly Writing
-
+### Key Practices for Localization-Friendly Writing
 
 | Practice                                        | Why It Matters                                       |
 | ----------------------------------------------- | ---------------------------------------------------- |
@@ -743,10 +688,9 @@ It starts with writing that’s clear, culture-neutral, and easy to adapt.
 | **Don’t hardcode values or labels**             | Keep UI strings and placeholders separate            |
 | **Use neutral date/time formats**               | Prefer ISO: `YYYY-MM-DD`, `14:00 UTC`                |
 
-***
+---
 
 ### ❌ Bad for Translation
-
 
 ```markdown
 You’ve nailed it—time to kick things off! 🎉
@@ -755,7 +699,6 @@ Click “Go” and let’s roll!
 
 ### ✅ Localization-Friendly Version
 
-
 ```markdown
 You're ready to begin.
 Click **Go** to start the process.
@@ -763,10 +706,9 @@ Click **Go** to start the process.
 
 > 🎯 Be specific, not clever. Translators will thank you.
 
-***
+---
 
-###  Placeholder Format
-
+### Placeholder Format
 
 When writing text that will include dynamic values (e.g., usernames, file paths), use clear and localizable syntax:
 
@@ -783,40 +725,36 @@ Avoid:
 Welcome, $username! Your file is in $path
 ```
 
-***
+---
 
-###  Helpful Tools
+### Helpful Tools
 
+- [Phrase](https://phrase.com) – Translation management platform
+- [Crowdin](https://crowdin.com) – Collaborative localization for docs
+- [LocalizationLint](https://github.com/DavidAnson/markdownlint) – Lint for localization issues in Markdown
 
-* [Phrase](https://phrase.com) – Translation management platform
-* [Crowdin](https://crowdin.com) – Collaborative localization for docs
-* [LocalizationLint](https://github.com/DavidAnson/markdownlint) – Lint for localization issues in Markdown
+---
 
-***
+### TL;DR
 
-###  TL;DR
-
-
-* Write for translation by writing clearly
-* Avoid wordplay and ambiguity
-* Use placeholders, not hardcoded strings
-* Respect language direction, spacing, and tone
+- Write for translation by writing clearly
+- Avoid wordplay and ambiguity
+- Use placeholders, not hardcoded strings
+- Respect language direction, spacing, and tone
 
 > If your doc can’t travel, it can’t scale.
 
-***
+---
 
 ## 11. Linking & Cross-Referencing
-
 
 _Teaching users how to navigate like pros._
 
 A good link is like a guidepost. It’s clear, descriptive, and helps the reader move forward confidently—without friction or confusion.
 
-***
+---
 
-###  Link Types & Formats
-
+### Link Types & Formats
 
 | Type               | Format                          | Example                                        |
 | ------------------ | ------------------------------- | ---------------------------------------------- |
@@ -826,10 +764,9 @@ A good link is like a guidepost. It’s clear, descriptive, and helps the reader
 
 ✅ Anchor links are based on the heading text, all lowercase, spaces → `-`, and special characters removed.
 
-***
+---
 
 ### ❌ Poor Linking Practices
-
 
 ```markdown
 Click [here](https://example.com) to continue.
@@ -841,7 +778,6 @@ Follow this link to [go back](#).
 
 ### ✅ Clean, Descriptive Links
 
-
 ```markdown
 To view our API setup process, [read the Setup Guide](../docs/api-setup.md).
 
@@ -850,10 +786,9 @@ Need the full changelog? [Check the release notes →](../RELEASES.md)
 Want to jump ahead? [Skip to Troubleshooting](#troubleshooting)
 ```
 
-***
+---
 
-###  Internal Anchors: How They Work
-
+### Internal Anchors: How They Work
 
 GitHub automatically creates an anchor link for every heading.
 
@@ -866,9 +801,9 @@ GitHub automatically creates an anchor link for every heading.
 
 Rules:
 
-* Use all lowercase
-* Replace spaces with hyphens `-`
-* Keep punctuation out unless it’s `&` or `-` (GitHub supports double hyphens for `&`)
+- Use all lowercase
+- Replace spaces with hyphens `-`
+- Keep punctuation out unless it’s `&` or `-` (GitHub supports double hyphens for `&`)
 
 ✅ Examples:
 
@@ -878,35 +813,32 @@ Rules:
 [See the Doc Types section](#5-doc-types--examples)
 ```
 
-***
+---
 
-###  Best Practices
+### Best Practices
 
-
-* ✅ Link nouns, not verbs:\
+- ✅ Link nouns, not verbs:\
   ❌ `Click here to learn more` → ✅ `Learn more about [markdown formatting]`
-* ✅ Test all links in the final rendered view (not just raw Markdown)
-* ✅ Keep anchor links updated if headings change
+- ✅ Test all links in the final rendered view (not just raw Markdown)
+- ✅ Keep anchor links updated if headings change
 
-***
+---
 
 > Good links feel invisible. They don’t interrupt.\
 > They just move the reader forward at the exact right moment.
 
-***
+---
 
 ## 12. Code & Command Snippets
-
 
 _Highlight with clarity, not clutter._
 
 Code blocks aren’t just for developers—they’re clarity boosters.\
 Done right, they make your docs feel helpful, visual, and skimmable.
 
-***
+---
 
-###  Code Block Guidelines
-
+### Code Block Guidelines
 
 | Rule                                | ✅ Do This                          |
 | ----------------------------------- | ---------------------------------- |
@@ -916,10 +848,9 @@ Done right, they make your docs feel helpful, visual, and skimmable.
 | Use inline code for filenames/flags | `` `README.md` ``, `` `--debug` `` |
 | Show example output when relevant   | Help readers verify results        |
 
-***
+---
 
 ### ❌ Poorly Formatted Example
-
 
 ```markdown
 To install, run the command below:
@@ -931,23 +862,21 @@ npm start
 
 ### ✅ Structured, Clear Version
 
-
 ````markdown
 ## Install the Package
 
 
-```bash
+```
 npm install my-package
-````
+````text
 
 ## Run the App
 
-
-```bash
-npm start
 ```
+npm start
+```text
 
-````
+```
 
 > 🧠 Avoid putting `$` before commands—it breaks copy-paste.
 
@@ -956,15 +885,14 @@ npm start
 ### ❌ Unlabeled, Unreadable JSON
 
 ```markdown
-````
+```
 
 { "success": true, "msg": "OK" }
 
-```
+```text
 ```
 
 ### ✅ Properly Labeled JSON Block
-
 
 ```json
 {
@@ -973,23 +901,21 @@ npm start
 }
 ```
 
-***
+---
 
 ### ✅ Inline Code Best Practices
 
-
 Use inline code (with single backticks) for:
 
-* Filenames: `` `config.yaml` ``
-* Flags: `` `--force` ``
-* Paths: `` `/usr/local/bin` ``
+- Filenames: `` `config.yaml` ``
+- Flags: `` `--force` ``
+- Paths: `` `/usr/local/bin` ``
 
 > Avoid bold or quotes for technical terms. Use `inline code` instead.
 
-***
+---
 
-###  TL;DR
-
+### TL;DR
 
 | ❌ Don't                      | ✅ Do                                 |
 | ---------------------------- | ------------------------------------ |
@@ -1000,10 +926,9 @@ Use inline code (with single backticks) for:
 
 > If the user has to squint at the code block, you’ve already lost them.
 
-***
+---
 
 ## 13. Admonitions & Callouts
-
 
 _⚠️ warnings, 💡 tips, ✅ examples._
 
@@ -1012,14 +937,13 @@ That means you need more than paragraphs. You need signals.
 
 Admonitions (also called "callouts") help readers:
 
-* Slow down before breaking something
-* Pay attention to what’s commonly missed
-* Feel reassured when they’re doing it right
+- Slow down before breaking something
+- Pay attention to what’s commonly missed
+- Feel reassured when they’re doing it right
 
-***
+---
 
-###  Types of Admonitions We Use
-
+### Types of Admonitions We Use
 
 | Type        | Emoji    | Use It When…                                   |
 | ----------- | -------- | ---------------------------------------------- |
@@ -1028,13 +952,11 @@ Admonitions (also called "callouts") help readers:
 | **Warning** | ⚠️       | A mistake here could break, delete, or confuse |
 | **Example** | ✅        | You’re reinforcing a concept with a use-case   |
 
-***
+---
 
-###  How to Format
-
+### How to Format
 
 #### ✅ Basic Markdown
-
 
 Use blockquotes with emojis + bold labels:
 
@@ -1045,7 +967,6 @@ Use blockquotes with emojis + bold labels:
 ```
 
 #### ✅ GitHub-Flavored Markdown (advanced)
-
 
 If using a static site generator (like Docusaurus or MkDocs), you can use custom containers:
 
@@ -1059,10 +980,9 @@ Never expose your API key in public repos.
 :::
 ```
 
-***
+---
 
 ### ❌ Flat and Forgettable
-
 
 ```markdown
 Be careful not to delete your database.
@@ -1071,39 +991,35 @@ You can use dry-run to test it first.
 
 ### ✅ Structured & Supportive
 
-
 ```markdown
 > ⚠️ **Warning:** Running this will erase all data in the `prod` environment.
 
 > 💡 **Tip:** Add `--dry-run` to preview which records would be deleted before confirming.
 ```
 
-***
+---
 
-###  When to Use Them
+### When to Use Them
 
-
-* ✅ If the reader might mess it up, use a **warning**
-* ✅ If there’s a faster path, use a **tip**
-* ✅ If it reinforces learning, add an **example**
-* ✅ If it’s helpful but non-critical, use a **note**
+- ✅ If the reader might mess it up, use a **warning**
+- ✅ If there’s a faster path, use a **tip**
+- ✅ If it reinforces learning, add an **example**
+- ✅ If it’s helpful but non-critical, use a **note**
 
 > Don’t overuse them.\
 > A doc full of callouts is just yelling at the user in emoji.
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
+- Use callouts like a mentor: kind, honest, and clear.
+- Don’t write “gotchas” after the fact—guide before the fall.
+- Use structure to show empathy: **highlight what matters before it’s too late**.
 
-* Use callouts like a mentor: kind, honest, and clear.
-* Don’t write “gotchas” after the fact—guide before the fall.
-* Use structure to show empathy: **highlight what matters before it’s too late**.
-
-***
+---
 
 ## 14. Asset Management
-
 
 _Folder conventions, image specs, and the hidden art of staying organized._
 
@@ -1112,14 +1028,13 @@ They’re visuals, downloads, embedded demos, diagrams, and often... a folder fu
 
 Let’s not do that.
 
-***
+---
 
-###  Folder Structure
-
+### Folder Structure
 
 All static assets—images, icons, charts, downloadable files—go here:
 
-```
+```text
 /assets/
    └── images/
    └── diagrams/
@@ -1132,10 +1047,9 @@ Use lowercase folder and file names, with hyphens instead of spaces: ✅ `api-fl
 
 > 📌 Tip: Keep assets **outside** your `/docs/` folder to avoid URL conflicts and clutter.
 
-***
+---
 
-###  Image Guidelines
-
+### Image Guidelines
 
 | Rule        | What To Do                                                                          |
 | ----------- | ----------------------------------------------------------------------------------- |
@@ -1145,17 +1059,15 @@ Use lowercase folder and file names, with hyphens instead of spaces: ✅ `api-fl
 | Compression | Use [TinyPNG](https://tinypng.com) or [Squoosh](https://squoosh.app) to reduce size |
 | Naming      | Use lowercase, hyphenated, descriptive filenames                                    |
 
-***
+---
 
 ### ❌ Bad Practice
-
 
 ```markdown
 ![img1](../docs/random_assets/finalfinal2.PNG)
 ```
 
 ### ✅ Better
-
 
 ```markdown
 ![User selecting a date range in the dashboard](../../assets/images/date-filter-ui.png)
@@ -1164,48 +1076,44 @@ Use lowercase folder and file names, with hyphens instead of spaces: ✅ `api-fl
 ✅ Alt text describes what’s shown and why it matters.\
 ✅ Path follows clean folder structure.
 
-***
+---
 
-###  Embeddable Files
-
+### Embeddable Files
 
 If you’re including downloads (PDFs, templates, etc.), place them under `/assets/downloads/`.
 
 Name them clearly:
 
-* `user-onboarding-checklist.pdf`
-* `quickstart-template.docx`
+- `user-onboarding-checklist.pdf`
+- `quickstart-template.docx`
 
 Avoid:
 
-* `final-checklist2 (copy).pdf`
-* `doc1.docx`
+- `final-checklist2 (copy).pdf`
+- `doc1.docx`
 
-***
+---
 
-###  Why This Matters
+### Why This Matters
 
-
-* Images without structure = broken links later
-* Large files = slow docs
-* Confusing names = contributor rage
+- Images without structure = broken links later
+- Large files = slow docs
+- Confusing names = contributor rage
 
 > Your readers may never see the asset folder—but your teammates will. Leave a trail of sanity.
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
+- Use `/assets/` with clear subfolders (`images`, `downloads`, `diagrams`)
+- Optimize every image—don’t dump raw screenshots
+- Describe visuals with intent—**alt text is content**
+- File names should be readable, reusable, and lowercase
 
-* Use `/assets/` with clear subfolders (`images`, `downloads`, `diagrams`)
-* Optimize every image—don’t dump raw screenshots
-* Describe visuals with intent—**alt text is content**
-* File names should be readable, reusable, and lowercase
-
-***
+---
 
 ## 15. Tables, Lists & Layouts
-
 
 _When to use which—and why your formatting matters._
 
@@ -1213,15 +1121,14 @@ Users don’t read docs like a novel.\
 They skim, scan, skip, and scroll.\
 Your structure should _support that behavior—not fight it_.
 
-***
+---
 
-###  When to Use a List
-
+### When to Use a List
 
 Use **bulleted lists** when:
 
-* There’s no specific order
-* You’re naming tools, options, concepts, requirements
+- There’s no specific order
+- You’re naming tools, options, concepts, requirements
 
 ```markdown
 - Install Node.js
@@ -1231,7 +1138,7 @@ Use **bulleted lists** when:
 
 Use **numbered lists** when:
 
-* Steps must be followed in a specific sequence
+- Steps must be followed in a specific sequence
 
 ```markdown
 1. Download the installer
@@ -1244,13 +1151,11 @@ Use **numbered lists** when:
 
 > To install the tool, follow these steps:
 
-***
+---
 
 ### ❌ Common Mistakes in Bullet Lists
 
-
-####  Mixed formats
-
+#### Mixed formats
 
 ```markdown
 - Clone the repo
@@ -1268,10 +1173,9 @@ Run the dev server after that
 - Open the browser
 ```
 
-***
+---
 
-####  Rambly, paragraph-length bullets
-
+#### Rambly, paragraph-length bullets
 
 ```markdown
 - First, you’re going to want to make sure your environment is set up correctly, which means checking Node version, Python path, and also ensuring that you have Git installed and configured properly.
@@ -1286,10 +1190,9 @@ Run the dev server after that
   - Git configured
 ```
 
-***
+---
 
-####  Inconsistent grammar or tone
-
+#### Inconsistent grammar or tone
 
 ```markdown
 - Creates the token
@@ -1308,15 +1211,14 @@ Run the dev server after that
 > 📌 Tip: Read your list out loud.\
 > If it sounds like a ramble or grammar rollercoaster, it probably is.
 
-***
+---
 
-###  When to Use a Table
-
+### When to Use a Table
 
 Use a **table** when:
 
-* You’re comparing values side-by-side
-* Listing options, flags, configs, or multiple attributes
+- You’re comparing values side-by-side
+- Listing options, flags, configs, or multiple attributes
 
 ```markdown
 | Flag        | Description                        | Default |
@@ -1330,10 +1232,9 @@ Use a **table** when:
 ✅ Use columns only when each one adds meaning\
 ❌ Avoid tables just to “make things look neat”
 
-***
+---
 
 ### ❌ Overdone Table
-
 
 ```markdown
 | Step | Instruction                                                                 |
@@ -1352,10 +1253,9 @@ Use a **table** when:
 3. Run the installer and follow prompts
 ```
 
-***
+---
 
-###  Visual Layout Patterns (Micro-Layouts)
-
+### Visual Layout Patterns (Micro-Layouts)
 
 Think in **building blocks**:
 
@@ -1369,26 +1269,24 @@ Think in **building blocks**:
 
 Don’t:
 
-* Nest 3+ levels deep
-* Stack multiple tables back-to-back
-* Mix long paragraphs into tables
+- Nest 3+ levels deep
+- Stack multiple tables back-to-back
+- Mix long paragraphs into tables
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Lists are for flow. Tables are for side-by-side comparison.
-* Don’t turn your prose into spreadsheets.
-* Use consistent tense and style across list items.
-* Respect your reader’s eyes—format like it matters.
+- Lists are for flow. Tables are for side-by-side comparison.
+- Don’t turn your prose into spreadsheets.
+- Use consistent tense and style across list items.
+- Respect your reader’s eyes—format like it matters.
 
 > If your doc looks like a receipt or a ransom note, reformat it.
 
-***
+---
 
 ## 16. Terminology & Glossary
-
 
 _Define and link key terms so your readers—and your writers—stay aligned._
 
@@ -1396,14 +1294,13 @@ Language isn't just what we write—it's the system that supports your product, 
 
 This glossary is your **source of truth** for:
 
-* What words mean
-* How they’re spelled and capitalized
-* When (and when not) to use them
+- What words mean
+- How they’re spelled and capitalized
+- When (and when not) to use them
 
-***
+---
 
-###  Why It Matters
-
+### Why It Matters
 
 | Without a glossary                                                   | With a glossary                           |
 | -------------------------------------------------------------------- | ----------------------------------------- |
@@ -1411,10 +1308,9 @@ This glossary is your **source of truth** for:
 | Users confused if “project,” “workspace,” and “account” are the same | Terms are defined, linked, and consistent |
 | Writers invent new phrases for the same concept                      | Everyone speaks the same doc language     |
 
-***
+---
 
-###  Example Glossary Table
-
+### Example Glossary Table
 
 | Term          | Definition                                          | Use it when…                      | Don’t confuse with |
 | ------------- | --------------------------------------------------- | --------------------------------- | ------------------ |
@@ -1424,29 +1320,27 @@ This glossary is your **source of truth** for:
 | **Project**   | A single unit of work inside a workspace            | Naming or scoping builds          | Repo, workspace    |
 | **Slug**      | A URL-friendly version of a name (`my-post-title`)  | Generating permalinks or doc URLs | ID, alias          |
 
-***
+---
 
-###  Tips for Maintaining the Glossary
+### Tips for Maintaining the Glossary
 
-
-* ✅ Add a new term when:
-  * You’ve used it 3+ times across docs
-  * You’ve had to explain it in comments or PRs
-  * It could be misinterpreted in another language
-*   ✅ Link to the glossary:
+- ✅ Add a new term when:
+  - You’ve used it 3+ times across docs
+  - You’ve had to explain it in comments or PRs
+  - It could be misinterpreted in another language
+- ✅ Link to the glossary:
 
     ```markdown
     See our [Glossary →](#16-terminology--glossary) for key definitions.
     ```
-* ✅ Define once. Then use consistently.
-* 🚫 Don’t:
-  * Redefine terms in every doc
-  * Assume technical users already know
+- ✅ Define once. Then use consistently.
+- 🚫 Don’t:
+  - Redefine terms in every doc
+  - Assume technical users already know
 
-***
+---
 
-###  Formatting Rules
-
+### Formatting Rules
 
 | Rule           | What to Follow                                                       |
 | -------------- | -------------------------------------------------------------------- |
@@ -1456,10 +1350,9 @@ This glossary is your **source of truth** for:
 | Capitalization | Only capitalize proper nouns (e.g. GitHub, Node.js)                  |
 | Plurals        | Use singular form as the glossary entry (e.g. `token`, not `tokens`) |
 
-***
+---
 
-###  Common Anti-Patterns
-
+### Common Anti-Patterns
 
 | Problem                                      | Fix                                               |
 | -------------------------------------------- | ------------------------------------------------- |
@@ -1467,21 +1360,19 @@ This glossary is your **source of truth** for:
 | Inconsistent capitalization (`Api` vs `API`) | Define casing rules once, follow everywhere       |
 | Jargon overload                              | Add plain English versions or usage examples      |
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Your glossary is a contract between writer and reader
-* Define once, use everywhere
-* Link generously—don’t force the reader to guess
-* Kill synonym drift before it kills your clarity
+- Your glossary is a contract between writer and reader
+- Define once, use everywhere
+- Link generously—don’t force the reader to guess
+- Kill synonym drift before it kills your clarity
 
 > Docs don’t get bloated because of too much info.\
 > They get bloated because of repeated definitions.
 
 ## 17. Doc Versioning & Changelogs
-
 
 _Semantic versions, last updated tags, and reader trust._
 
@@ -1489,14 +1380,13 @@ Your readers won’t always remember what they read last time—but your docs sh
 
 Versioning and changelogs help users know:
 
-* If the doc they’re reading is up to date
-* What’s changed since the last time they followed the steps
-* Whether the current instructions match their software version
+- If the doc they’re reading is up to date
+- What’s changed since the last time they followed the steps
+- Whether the current instructions match their software version
 
-***
+---
 
-###  Versioning Rules (Docs ≠ Product)
-
+### Versioning Rules (Docs ≠ Product)
 
 Use [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) for **published docs**, especially when they map to product releases.
 
@@ -1514,10 +1404,9 @@ _Last updated: May 21, 2025 • Version: 1.2.3_
 
 ✅ Pro tip: Don’t confuse product version with doc version—track both if needed.
 
-***
+---
 
 ### ️ Creating a Great CHANGELOG.md
-
 
 Keep a root-level changelog that summarizes updates in **plain English** and separates additions, fixes, and changes:
 
@@ -1544,13 +1433,11 @@ Keep a root-level changelog that summarizes updates in **plain English** and sep
 - Moved examples into `/examples/` folder
 ```
 
-***
+---
 
 ### ❌ Dont Do This
 
-
 #### 1. ❌ Vague Commit Messages
-
 
 ```bash
 git commit -m "update docs"
@@ -1562,10 +1449,9 @@ git commit -m "update docs"
 git commit -m "docs: clarify setup steps in quickstart guide"
 ```
 
-***
+---
 
 #### 2. ❌ Messy Changelog
-
 
 ```markdown
 - Fixed some stuff
@@ -1585,10 +1471,9 @@ git commit -m "docs: clarify setup steps in quickstart guide"
 - New “Writing Principles” subsection with examples
 ```
 
-***
+---
 
 #### 3. ❌ No “Last Updated” Info
-
 
 ```markdown
 ## Setup Guide
@@ -1605,10 +1490,9 @@ Step 1: Install the CLI...
 _Last updated: May 21, 2025_
 ```
 
-***
+---
 
 ### ✅ Where to Show Versioning
-
 
 | Place             | What to Show                                  |
 | ----------------- | --------------------------------------------- |
@@ -1618,22 +1502,20 @@ _Last updated: May 21, 2025_
 
 > Don’t just keep docs updated—show that they’re updated.
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Use semantic versioning when your docs follow product changes
-* Maintain a clean, readable `/CHANGELOG.md`
-* Always show “last updated” info in public-facing docs
-* Track both technical and editorial updates
-* Version commits clearly so humans—not just tools—can follow
+- Use semantic versioning when your docs follow product changes
+- Maintain a clean, readable `/CHANGELOG.md`
+- Always show “last updated” info in public-facing docs
+- Track both technical and editorial updates
+- Version commits clearly so humans—not just tools—can follow
 
 > Code tells the computer what changed.\
 > Changelogs tell the humans.
 
 ## 18. Review & Feedback Process
-
 
 _How to propose, review, and merge changes without losing your mind—or your voice._
 
@@ -1642,39 +1524,35 @@ They’re reviewed, challenged, edited, and improved—collaboratively.
 
 This section defines how we do that:
 
-* How to submit doc changes
-* How we review with care, not ego
-* How we merge with clarity and control
+- How to submit doc changes
+- How we review with care, not ego
+- How we merge with clarity and control
 
-***
+---
 
 ### ✍️ Submitting a Doc Change (Pull Request Etiquette)
 
-
 ✅ Before opening a pull request:
 
-* Read the [Style Guide](../STYLE-GUIDE/STYLE-GUIDE.md)
-* Check for existing terms in the [Glossary](./#16-terminology--glossary)
-* Use meaningful commit messages
-* Add a brief PR description explaining:
-  * What changed
-  * Why it changed
-  * If any related sections were affected
+- Read the [Style Guide](../STYLE-GUIDE/STYLE-GUIDE.md)
+- Check for existing terms in the [Glossary](./#16-terminology--glossary)
+- Use meaningful commit messages
+- Add a brief PR description explaining:
+  - What changed
+  - Why it changed
+  - If any related sections were affected
 
 #### ❌ Vague PR Description
-
 
 > “Fixed some typos and stuff.”
 
 #### ✅ Better
 
-
 > “Clarified token vs. key usage in authentication section. Added alt text to 2 missing diagrams.”
 
-***
+---
 
-###  How We Review
-
+### How We Review
 
 ✅ We use this 4-check system:
 
@@ -1687,10 +1565,9 @@ This section defines how we do that:
 
 > Bonus check: Will the _next contributor_ understand what’s happening here?
 
-***
+---
 
-###  How to Give Better Feedback
-
+### How to Give Better Feedback
 
 | ❌ Don't Say                           | ✅ Say Instead                                             |
 | ------------------------------------- | --------------------------------------------------------- |
@@ -1700,40 +1577,36 @@ This section defines how we do that:
 
 > Kindness isn’t optional—it’s part of clarity.
 
-***
+---
 
 ### ✅ Merging Guidelines
 
+- Every major update needs 1+ reviewer approval
+- Editorial changes (grammar, spacing, internal links) can be merged solo
+- Contributors **must** tag the latest doc version and update the changelog if the structure changes
+- All merges must follow conventional commit format
 
-* Every major update needs 1+ reviewer approval
-* Editorial changes (grammar, spacing, internal links) can be merged solo
-* Contributors **must** tag the latest doc version and update the changelog if the structure changes
-* All merges must follow conventional commit format
+---
 
-***
+### Pro Tips
 
-###  Pro Tips
+- If a change “feels off,” suggest—not block
+- If a section is unclear, ask _what it’s trying to do_, not just how it’s written
+- Don’t just review the code—_review the experience_
 
+---
 
-* If a change “feels off,” suggest—not block
-* If a section is unclear, ask _what it’s trying to do_, not just how it’s written
-* Don’t just review the code—_review the experience_
+### TL;DR
 
-***
-
-###  TL;DR
-
-
-* Reviews are guardrails, not gates
-* Propose clearly, review kindly, and merge consistently
-* Ask: “Will this make someone’s job easier?”—that’s the metric
+- Reviews are guardrails, not gates
+- Propose clearly, review kindly, and merge consistently
+- Ask: “Will this make someone’s job easier?”—that’s the metric
 
 > Good feedback doesn't just fix the doc. It teaches the writer.
 
-***
+---
 
 ## 19. Automation & Tooling
-
 
 _Linting, CI checks, and the bots that make us better—not bitter._
 
@@ -1741,15 +1614,14 @@ Good automation doesn’t just enforce rules—it makes good writing easier.
 
 We use light-touch automation to:
 
-* Keep formatting and structure clean
-* Prevent broken links and missing alt text
-* Avoid noisy or unstructured commits
-* Reduce reviewer burden on repetitive issues
+- Keep formatting and structure clean
+- Prevent broken links and missing alt text
+- Avoid noisy or unstructured commits
+- Reduce reviewer burden on repetitive issues
 
-***
+---
 
 ### ⚙️ Recommended Tools
-
 
 | Tool           | What It Does                                                | When We Use It             |
 | -------------- | ----------------------------------------------------------- | -------------------------- |
@@ -1759,10 +1631,9 @@ We use light-touch automation to:
 | `textlint`     | Catch long sentences, passive voice, and filler words       | During reviews             |
 | `husky`        | Runs checks before commit/push                              | Used with pre-commit hooks |
 
-***
+---
 
-###  Example: Pre-Commit Hook with `markdownlint`
-
+### Example: Pre-Commit Hook with `markdownlint`
 
 `.husky/pre-commit`
 
@@ -1774,10 +1645,9 @@ npx markdownlint "**/*.md"
 
 ✅ This ensures you won’t accidentally commit a doc with broken headings or list formatting.
 
-***
+---
 
 ### ✅ GitHub Actions for Docs
-
 
 You can also add automation to your GitHub repo with minimal overhead.
 
@@ -1799,29 +1669,25 @@ jobs:
 
 ✅ This checks every PR for Markdown issues automatically.
 
-***
+---
 
-###  Dont Over-Automate
-
+### Dont Over-Automate
 
 #### ❌ Anti-patterns
 
-
-* Blocking PRs because a line is 81 characters
-* Forcing tools that contributors can’t easily install
-* Adding six linters that contradict each other
+- Blocking PRs because a line is 81 characters
+- Forcing tools that contributors can’t easily install
+- Adding six linters that contradict each other
 
 #### ✅ Better Approach
 
+- Catch _preventable friction_ (like broken anchors or missing alt text)
+- Format only what matters (spacing, heading structure)
+- Use automation to assist—not intimidate
 
-* Catch _preventable friction_ (like broken anchors or missing alt text)
-* Format only what matters (spacing, heading structure)
-* Use automation to assist—not intimidate
+---
 
-***
-
-###  What to Automate vs Review Manually
-
+### What to Automate vs Review Manually
 
 | Automate                                | Review Manually                |
 | --------------------------------------- | ------------------------------ |
@@ -1829,21 +1695,19 @@ jobs:
 | Commit style (`feat:`, `fix:`)          | Doc structure and logic        |
 | Typos, spacing                          | Is this helpful to the reader? |
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Use `markdownlint`, `alex`, and pre-commit hooks for clarity and inclusivity
-* Automate the boring stuff so humans can focus on meaning
-* Don’t let bots kill creativity—use them to surface quality
+- Use `markdownlint`, `alex`, and pre-commit hooks for clarity and inclusivity
+- Automate the boring stuff so humans can focus on meaning
+- Don’t let bots kill creativity—use them to surface quality
 
 > Automation should clean your docs—not erase their soul.
 
-***
+---
 
 ## 20. SEO & Discoverability
-
 
 _Slugs, meta-tags, internal linking—and how to be found without selling your soul._
 
@@ -1852,10 +1716,9 @@ Search Engine Optimization (SEO) isn’t about gaming Google—it’s about writ
 
 > Good SEO = Helping people find the right answer, right when they need it.
 
-***
+---
 
-###  What Impacts Discoverability in Docs
-
+### What Impacts Discoverability in Docs
 
 | Element               | Why It Matters                                                         |
 | --------------------- | ---------------------------------------------------------------------- |
@@ -1865,10 +1728,9 @@ Search Engine Optimization (SEO) isn’t about gaming Google—it’s about writ
 | **Link structure**    | Internal links build hierarchy and guide user flow                     |
 | **Anchor names**      | Human-readable anchors improve link trust and click-throughs           |
 
-***
+---
 
 ### ✅ Writing SEO-Friendly Titles
-
 
 **Bad:**
 
@@ -1886,10 +1748,9 @@ Search Engine Optimization (SEO) isn’t about gaming Google—it’s about writ
 
 ✅ Be specific. Use terms your audience is likely to search for.
 
-***
+---
 
-###  Writing Meta Descriptions (If Your Platform Supports It)
-
+### Writing Meta Descriptions (If Your Platform Supports It)
 
 In frontmatter or metadata blocks:
 
@@ -1900,21 +1761,19 @@ description: "Learn how to configure Slack integration with webhooks, auth, and 
 
 > ✅ Think like a user: “If I saw this in search, would I click it?”
 
-***
+---
 
-###  Link Placement Best Practices
+### Link Placement Best Practices
 
-
-* Link **related docs inline** where context is relevant\
+- Link **related docs inline** where context is relevant\
   ✅ _“To configure the webhook,_ [_see our error-handling guide_](webhook-errors.md)_.”_
-* Avoid generic anchors like `click here`\
+- Avoid generic anchors like `click here`\
   ✅ _“_[_See OAuth setup instructions →_](oauth-setup.md)_”_
-* Use **relative paths** for internal links (`./`, not full domain)
+- Use **relative paths** for internal links (`./`, not full domain)
 
-***
+---
 
 ### ❌ Common SEO Pitfalls
-
 
 | Mistake                          | Better Practice                                      |
 | -------------------------------- | ---------------------------------------------------- |
@@ -1923,10 +1782,9 @@ description: "Learn how to configure Slack integration with webhooks, auth, and 
 | Using raw URLs                   | Use `[descriptive text](url)` instead                |
 | Keyword stuffing                 | Prioritize clarity—readers > robots                  |
 
-***
+---
 
-###  Tools for Smarter Docs SEO
-
+### Tools for Smarter Docs SEO
 
 | Tool                                                                | Use Case                              |
 | ------------------------------------------------------------------- | ------------------------------------- |
@@ -1935,24 +1793,22 @@ description: "Learn how to configure Slack integration with webhooks, auth, and 
 | [Ahrefs Free Tools](https://ahrefs.com/webmaster-tools)             | Check backlinks and crawl health      |
 | [markdown-link-check](https://github.com/tcort/markdown-link-check) | Detect broken links in `.md` files    |
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Title with clarity, not cleverness
-* Write 1–2 sentence summaries (meta descriptions)
-* Use anchor links with purpose—not just out of habit
-* Avoid stuffing keywords; favor discoverability through usefulness
-* Think “search phrases,” not buzzwords
+- Title with clarity, not cleverness
+- Write 1–2 sentence summaries (meta descriptions)
+- Use anchor links with purpose—not just out of habit
+- Avoid stuffing keywords; favor discoverability through usefulness
+- Think “search phrases,” not buzzwords
 
 > Search engines don’t rank what’s beautiful.\
 > They rank what’s useful—and readable.
 
-***
+---
 
 ## 21. Living Documentation
-
 
 _Review schedules, ownership, and docs that age gracefully._
 
@@ -1962,14 +1818,13 @@ This section helps you keep your documentation relevant, helpful, and trusted—
 
 A “living” document means:
 
-* It reflects the current state of the product
-* It has an owner, not just a creator
-* It signals when it’s outdated or ready for removal
+- It reflects the current state of the product
+- It has an owner, not just a creator
+- It signals when it’s outdated or ready for removal
 
-***
+---
 
-###  Signs Your Doc Is Dying
-
+### Signs Your Doc Is Dying
 
 | Symptom                                     | What It Means                          |
 | ------------------------------------------- | -------------------------------------- |
@@ -1978,10 +1833,9 @@ A “living” document means:
 | Screenshots show an old UI                  | The product evolved but the doc didn’t |
 | It only made sense during a sprint          | The doc has lost long-term context     |
 
-***
+---
 
 ### ✅ Review Cadence Suggestions
-
 
 | Doc Type                 | Review Every…                        |
 | ------------------------ | ------------------------------------ |
@@ -1992,43 +1846,41 @@ A “living” document means:
 
 > If it impacts users, review it like a product.
 
-***
+---
 
 ### ‍ Assigning Ownership
 
-
 Every major doc should have:
 
-* A **primary maintainer** (can be shared across teams)
-* A clear history of contributors (visible via commits or metadata)
-* A changelog or “last updated” tag to guide readers and editors
+- A **primary maintainer** (can be shared across teams)
+- A clear history of contributors (visible via commits or metadata)
+- A changelog or “last updated” tag to guide readers and editors
 
 ```markdown
 _Last reviewed: April 2025 by @devdocqueen_
 ```
 
-***
+---
 
-###  How to Retire a Doc (Gracefully)
-
+### How to Retire a Doc (Gracefully)
 
 Don’t just delete it. Deprecate with dignity.
 
 ✅ Steps:
 
-1.  Add a banner to the top of the doc:
+1. Add a banner to the top of the doc:
 
     ```markdown
     > ⚠️ **Deprecated:** This guide is outdated as of April 2024.
     > For the latest setup, [see the updated OAuth guide](./oauth-v2.md).
     ```
+
 2. Move to `/archive/` or clearly label with `[DEPRECATED]` in the filename
 3. Remove it from nav menus and TOC if it's not actively needed
 
-***
+---
 
-###  Proactive Doc Maintenance Checklist
-
+### Proactive Doc Maintenance Checklist
 
 | Task                                  | Frequency    |
 | ------------------------------------- | ------------ |
@@ -2037,10 +1889,9 @@ Don’t just delete it. Deprecate with dignity.
 | Validate internal links still resolve | Monthly      |
 | Ask users what’s unclear or missing   | Continuously |
 
-***
+---
 
 ### ❌ What Not to Do
-
 
 | Mistake                      | Better Approach                                      |
 | ---------------------------- | ---------------------------------------------------- |
@@ -2048,23 +1899,21 @@ Don’t just delete it. Deprecate with dignity.
 | Delete docs without redirect | Deprecate visibly or archive with links              |
 | Ignore reader feedback       | Add clarifications or open a PR—even for small notes |
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Assign doc owners and review cycles—don’t let docs drift
-* Mark outdated guides with version labels or warnings
-* Archive responsibly, and always point readers to what’s next
-* Keep changelogs and last-reviewed metadata visible
+- Assign doc owners and review cycles—don’t let docs drift
+- Mark outdated guides with version labels or warnings
+- Archive responsibly, and always point readers to what’s next
+- Keep changelogs and last-reviewed metadata visible
 
 > Living docs aren’t constantly changing.\
 > They’re just never ignored.
 
-***
+---
 
 ## 22. AI-Assisted Writing
-
 
 _Guidance on responsible, ethical, and effective use of AI in docs._
 
@@ -2072,14 +1921,13 @@ AI can draft, polish, rephrase, reformat—and hallucinate.
 
 This section helps you use AI as a writing assistant—not a ghostwriter—and ensures your documentation stays:
 
-* Clear
-* Credible
-* Human-first
+- Clear
+- Credible
+- Human-first
 
-***
+---
 
-###  What AI Can Help With
-
+### What AI Can Help With
 
 | Task                   | AI Is Useful For…                                  |
 | ---------------------- | -------------------------------------------------- |
@@ -2089,10 +1937,9 @@ This section helps you use AI as a writing assistant—not a ghostwriter—and e
 | Translating tone       | Converting corporate speak to plain English        |
 | Brainstorming examples | Coming up with analogies, metaphors, or edge cases |
 
-***
+---
 
 ### ❌ What AI Should NOT Do
-
 
 | Task                               | Why It’s Risky                                 |
 | ---------------------------------- | ---------------------------------------------- |
@@ -2102,10 +1949,9 @@ This section helps you use AI as a writing assistant—not a ghostwriter—and e
 | Fabricate citations or links       | Breaks trust immediately                       |
 | Replace writer ownership           | Undermines author intent, empathy, and context |
 
-***
+---
 
-###  Ethical Considerations
-
+### Ethical Considerations
 
 | Principle                | What It Means                                                            |
 | ------------------------ | ------------------------------------------------------------------------ |
@@ -2118,10 +1964,9 @@ This section helps you use AI as a writing assistant—not a ghostwriter—and e
 > ✍️ Writers write.\
 > AI assists—but humans are responsible.
 
-***
+---
 
 ### ✅ Ethical AI Workflow
-
 
 1. **Prompt clearly**\
    &#xNAN;_“Rewrite this section for a beginner. Avoid jargon, but don’t lose technical meaning.”_
@@ -2132,42 +1977,38 @@ This section helps you use AI as a writing assistant—not a ghostwriter—and e
 4. **Mark what’s incomplete**\
    &#xNAN;_&#x41;dd `[INSERT real screenshot of new UI here]` or `[Placeholder: list common error codes]`._
 
-***
+---
 
-###  Prompt Design: Good vs Bad
-
+### Prompt Design: Good vs Bad
 
 Writing for AI is a skill. Here’s how to level up:
 
-#### ❌ Bad Prompt:
-
+#### ❌ Bad Prompt
 
 > “Write API documentation for my product.”
 
 ❌ What you get:
 
-* Hallucinated endpoints
-* Placeholder tokens
-* Random headers and features you don’t support
-* Generic tone with no context
+- Hallucinated endpoints
+- Placeholder tokens
+- Random headers and features you don’t support
+- Generic tone with no context
 
-***
+---
 
-#### ✅ Better Prompt:
-
+#### ✅ Better Prompt
 
 > “Write a short Getting Started section for a REST API with three endpoints: `/login`, `/logout`, and `/profile`. Focus on tone clarity over cleverness. Audience is mid-level devs familiar with Postman.”
 
 ✅ What you get:
 
-* Role-aware, usable draft
-* Structure and examples tailored to real devs
-* Something you can edit, not trash
+- Role-aware, usable draft
+- Structure and examples tailored to real devs
+- Something you can edit, not trash
 
-***
+---
 
-#### ❌ Bad Prompt:
-
+#### ❌ Bad Prompt
 
 > “Explain JSON to a non-techie.”
 
@@ -2177,10 +2018,9 @@ Writing for AI is a skill. Here’s how to level up:
 
 ✅ Zzzzz...
 
-***
+---
 
-#### ✅ Better Prompt:
-
+#### ✅ Better Prompt
 
 > “Explain JSON to a non-technical HR manager who understands spreadsheets. Use a friendly tone. Compare it to a table of columns and rows.”
 
@@ -2190,10 +2030,9 @@ Writing for AI is a skill. Here’s how to level up:
 
 Now that’s **readable and reusable**.
 
-***
+---
 
 ### ⚠️ Common Pitfalls with AI-Written Docs
-
 
 | Mistake                   | Real Impact                                 |
 | ------------------------- | ------------------------------------------- |
@@ -2202,13 +2041,11 @@ Now that’s **readable and reusable**.
 | Not attributing AI output | Breaks trust and ownership                  |
 | Skipping fact-checking    | Introduces silent bugs or false features    |
 
-***
+---
 
 ### ✅ Good AI Use vs Bad AI Use
 
-
-#### ✅ Good:
-
+#### ✅ Good
 
 ```markdown
 > AI-generated: Drafted alt text for all diagrams.
@@ -2216,8 +2053,7 @@ Now that’s **readable and reusable**.
 > Final: Added context-specific screenshots and corrected link targets.
 ```
 
-#### ❌ Bad:
-
+#### ❌ Bad
 
 ```markdown
 > AI-generated: Wrote entire user guide.
@@ -2225,23 +2061,21 @@ Now that’s **readable and reusable**.
 > Result: Broken commands, fake endpoints, inconsistent tone.
 ```
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Use AI to support—not replace—your writing
-* Disclose, review, and rewrite as needed
-* Write better prompts, and treat AI like an intern—not a savior
-* If it sounds fake, bloated, or risky—it probably is
+- Use AI to support—not replace—your writing
+- Disclose, review, and rewrite as needed
+- Write better prompts, and treat AI like an intern—not a savior
+- If it sounds fake, bloated, or risky—it probably is
 
 > AI can accelerate writing.\
 > But only humans can write with **intent, empathy, and truth**.
 
-***
+---
 
 ## 23. Multi-Format Output
-
 
 _PDF, slides, video scripts—and writing that works everywhere._
 
@@ -2249,19 +2083,18 @@ Your documentation may need to live beyond Markdown.
 
 This section helps you write with adaptability in mind—so your content can move between:
 
-* Slideshows
-* Tutorials or videos
-* Voice-over scripts
-* Interactive tools
-* PDFs or printed booklets
+- Slideshows
+- Tutorials or videos
+- Voice-over scripts
+- Interactive tools
+- PDFs or printed booklets
 
 > Great documentation isn’t tied to its format.\
 > It’s built on clarity, rhythm, and hierarchy.
 
-***
+---
 
-###  Format-Agnostic Writing Principles
-
+### Format-Agnostic Writing Principles
 
 | Rule                                 | Why It Matters                                   |
 | ------------------------------------ | ------------------------------------------------ |
@@ -2271,13 +2104,11 @@ This section helps you write with adaptability in mind—so your content can mov
 | Separate content from visuals        | Easier to reuse content across formats           |
 | Use consistent callouts and examples | Helps in script narration or alt-text captions   |
 
-***
+---
 
-###  Adapting a Doc to Other Formats
-
+### Adapting a Doc to Other Formats
 
 #### ✅ Slide Deck (Presentation)
-
 
 | Doc Element  | Slide Equivalent                  |
 | ------------ | --------------------------------- |
@@ -2288,7 +2119,6 @@ This section helps you write with adaptability in mind—so your content can mov
 
 #### ✅ Video Tutorial or Script
 
-
 | Doc Element       | Spoken Equivalent         |
 | ----------------- | ------------------------- |
 | Step-by-step list | Walkthrough narration     |
@@ -2296,10 +2126,9 @@ This section helps you write with adaptability in mind—so your content can mov
 | Visual references | Camera zooms / highlights |
 | Examples          | Demo clips or animations  |
 
-***
+---
 
-###  Multi-Format Layout Template
-
+### Multi-Format Layout Template
 
 ```markdown
 ## Section Title
@@ -2320,10 +2149,9 @@ _1-sentence intro for context_
 “Let’s start by cloning the repo and checking if the setup works locally…”
 ```
 
-***
+---
 
 ### ❌ Pitfalls to Avoid
-
 
 | Problem                              | Fix                                                  |
 | ------------------------------------ | ---------------------------------------------------- |
@@ -2332,10 +2160,9 @@ _1-sentence intro for context_
 | Visuals with no description          | Add alt-text or captions                             |
 | Repetitive formatting across formats | Keep one clean source and generate outputs as needed |
 
-***
+---
 
-###  Tools to Export From Markdown
-
+### Tools to Export From Markdown
 
 | Tool                                                      | Output                           | Notes                                    |
 | --------------------------------------------------------- | -------------------------------- | ---------------------------------------- |
@@ -2344,22 +2171,20 @@ _1-sentence intro for context_
 | [Docsify](https://docsify.js.org/)                        | Web docs                         | Live preview-friendly                    |
 | [Lunacy + Figma Plugins](https://www.figma.com/community) | Graphics/slides from doc layouts | For visual-first teams                   |
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Write with format flexibility in mind—structure > style
-* Keep language concise and modular for reuse in slides, videos, scripts, and more
-* Separate content from layout, always add alt text
-* Use tools to export—not rewrite
+- Write with format flexibility in mind—structure > style
+- Keep language concise and modular for reuse in slides, videos, scripts, and more
+- Separate content from layout, always add alt text
+- Use tools to export—not rewrite
 
 > A well-written doc should be easy to **read**, easy to **present**, and easy to **teach**.
 
-***
+---
 
 ## 24. Evolution Rules
-
 
 _How and when this guide updates—because writing standards grow, too._
 
@@ -2368,43 +2193,40 @@ They’re living agreements—meant to evolve with your team, your audience, and
 
 This section defines how we:
 
-* Propose changes to the guide
-* Decide what gets added, rejected, or rewritten
-* Keep the guide relevant without constant churn
+- Propose changes to the guide
+- Decide what gets added, rejected, or rewritten
+- Keep the guide relevant without constant churn
 
-***
+---
 
-###  When Should the Style Guide Change?
-
+### When Should the Style Guide Change?
 
 ✅ Add or revise a section when:
 
-* There’s **repeated confusion** across docs or contributors
-* A new format or tool (e.g. AI, localization, video) becomes common
-* You’ve spotted **outdated guidance or broken rules**
-* Feedback or onboarding shows friction
+- There’s **repeated confusion** across docs or contributors
+- A new format or tool (e.g. AI, localization, video) becomes common
+- You’ve spotted **outdated guidance or broken rules**
+- Feedback or onboarding shows friction
 
 ✅ Avoid changes just because:
 
-* It’s “how you personally like to write”
-* You want to make a sentence sound cooler
-* You’re trying to match external brands or trends
+- It’s “how you personally like to write”
+- You want to make a sentence sound cooler
+- You’re trying to match external brands or trends
 
 > This guide evolves for the **collective clarity**—not individual voice.
 
-***
+---
 
-###  How to Propose a Change
-
+### How to Propose a Change
 
 Every style edit—no matter how small—should:
 
-* Be submitted as a Pull Request
-* Include a short rationale in the PR description
-* Reference an example of where the current rule caused confusion or inconsistency
+- Be submitted as a Pull Request
+- Include a short rationale in the PR description
+- Reference an example of where the current rule caused confusion or inconsistency
 
-#### ✅ Example PR Description:
-
+#### ✅ Example PR Description
 
 ```markdown
 This PR suggests rewording the “Emphasis Rules” section to better distinguish between emphasis for emotion vs. technical commands.
@@ -2414,10 +2236,9 @@ We noticed contributors overusing `**bold**` where italics were meant to soften 
 Issue raised in #42 and #51.
 ```
 
-***
+---
 
-###  Who Approves Changes?
-
+### Who Approves Changes?
 
 | Change Type                             | Reviewer Required                      |
 | --------------------------------------- | -------------------------------------- |
@@ -2427,10 +2248,9 @@ Issue raised in #42 and #51.
 
 ✅ Use GitHub Discussions or issues for large proposals before writing a PR.
 
-***
+---
 
 ### ️ Versioning the Style Guide
-
 
 The style guide has its own semantic version.
 
@@ -2445,31 +2265,29 @@ _Last updated: May 21, 2025_
 | `0.x.0`      | Added sections, rules, or glossary terms |
 | `0.0.x`      | Fixes, rewording, formatting cleanup     |
 
-***
+---
 
-###  What Doesnt Change Easily
-
+### What Doesnt Change Easily
 
 Some sections require higher scrutiny before edits:
 
-* Tone & Voice
-* Glossary Definitions
-* Accessibility Rules
-* Ethical/AI Usage Standards
+- Tone & Voice
+- Glossary Definitions
+- Accessibility Rules
+- Ethical/AI Usage Standards
 
 > These are foundational.\
 > Updates should reflect real-world pain—not personal taste.
 
-***
+---
 
-###  TL;DR
+### TL;DR
 
-
-* Style guides are agreements, not absolutes
-* Propose changes with examples, not opinions
-* Version the guide, track the changes, and explain the _why_
-* Change what serves the reader—not what flatters the writer
+- Style guides are agreements, not absolutes
+- Propose changes with examples, not opinions
+- Version the guide, track the changes, and explain the _why_
+- Change what serves the reader—not what flatters the writer
 
 > This guide evolves—but only for the right reasons.
 
-***
+---

--- a/style-guide/visual-style.md
+++ b/style-guide/visual-style.md
@@ -10,50 +10,65 @@ last_reviewed: 2025-07-30
 # Visual Style
 
 ## Overview
+
 - Establish consistent visuals for documentation.
 
 ## Why It Matters
+
 - Cohesive design reinforces trust and readability.
 
 ## Audience, Scope & Personas
+
 - Writers, designers, and developers contributing visuals.
 
 ## Prerequisites
+
 - Familiarity with basic design principles and markdown formatting.
 
 ## Security, Compliance & Privacy
+
 - Ensure images contain no confidential information.
 
 ## Tasks & Step-by-Step Instructions
+
 1. Select accessible color palettes.
 2. Use web-safe fonts consistently.
 3. Keep page layouts responsive and simple.
 
 ## Access Control & Permissions (RBAC guidelines)
+
 - No special permissions required; contributions are open via pull requests.
 
 ## Practical Examples & Templates (✅/❌)
+
 - ✅ High-contrast text against backgrounds.
 - ❌ Overly decorative fonts that reduce legibility.
 
 ## Known Issues & Friction Points
+
 - Colors may appear differently on various screens.
 
 ## Tips & Best Practices
+
 - Prioritize readability over aesthetics.
 - Use whitespace to separate major sections.
 
 ## Troubleshooting Guidance
+
 - If styles fail to render, check your CSS or markdown syntax.
 
 ## Dependencies, Risks & Escalation Path
+
 - Relies on base CSS framework; escalate major visual issues to the docs team.
 
 ## Success Metrics & Outcomes
+
 - Decreased visual inconsistencies across documentation.
 
 ## Resources & References
+
 - [W3C Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/)
 
 ## Last Reviewed / Last Updated
+
 2025-07-30


### PR DESCRIPTION
## Summary
- merge latest `main` to incorporate lint workflow and ignore patterns
- resolve contributing guide conflict with updated review metadata
- ensure package scripts and validation tooling respect `.markdownlintignore`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df36923d48322b132b75c269afed2